### PR TITLE
fix: use base_image for Windows version code instead of os_variant

### DIFF
--- a/backend/cyroid/api/vms.py
+++ b/backend/cyroid/api/vms.py
@@ -285,7 +285,8 @@ def start_vm(vm_id: UUID, db: DBSession, current_user: CurrentUser):
 
                 # Determine Windows version (VM setting takes priority over template)
                 # Version codes: 11, 11l, 11e, 10, 10l, 10e, 8e, 7u, vu, xp, 2k, 2025, 2022, 2019, 2016, 2012, 2008, 2003
-                windows_version = vm.windows_version or template.os_variant or "11"
+                # Use base_image for version code (e.g., "2019"), NOT os_variant (e.g., "Windows Server 2019")
+                windows_version = vm.windows_version or template.base_image or "11"
 
                 # Determine ISO path (VM setting takes priority)
                 iso_path = vm.iso_path or (template.cached_iso_path if hasattr(template, 'cached_iso_path') and template.cached_iso_path else None)


### PR DESCRIPTION
## Summary
- Fix Windows VM creation failing with invalid VERSION error

## Problem
When creating Windows VMs, the `VERSION` environment variable for dockur/windows was being set to the human-readable `os_variant` (e.g., "Windows Server 2019") instead of the version code (e.g., "2019") from `base_image`.

This caused dockur/windows to fail with:
```
ERROR: Invalid VERSION specified, value "Windows Server 2019" is not recognized!
```

## Solution
Changed line 288 in `backend/cyroid/api/vms.py` to use `template.base_image` instead of `template.os_variant` when determining the Windows version code.

## Test plan
- [x] Tested with Windows Server 2019 VM - now downloads and installs correctly
- [x] Verified VERSION is set to "2019" instead of "Windows Server 2019"

🤖 Generated with [Claude Code](https://claude.ai/code)