### PR TITLE
fix: sync frontend deps on startup when package.json changes

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,11 +3,17 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-COPY package.json ./
+# Install dependencies first (for layer caching on fresh builds)
+COPY package.json package-lock.json* ./
 RUN npm install
+
+# Copy entrypoint script that syncs deps when package.json changes
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 COPY . .
 
 EXPOSE 5173
 
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["npm", "run", "dev"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Ensure node_modules are in sync with package.json
+# This handles the case where a persistent volume has stale dependencies
+
+HASH_FILE="/app/node_modules/.package-json-hash"
+CURRENT_HASH=$(md5sum /app/package.json | cut -d' ' -f1)
+
+if [ -f "$HASH_FILE" ]; then
+    STORED_HASH=$(cat "$HASH_FILE")
+else
+    STORED_HASH=""
+fi
+
+if [ "$CURRENT_HASH" != "$STORED_HASH" ] || [ ! -d "/app/node_modules/react" ]; then
+    echo "Package.json changed or node_modules incomplete - running npm install..."
+    npm install
+    echo "$CURRENT_HASH" > "$HASH_FILE"
+else
+    echo "Dependencies up to date"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Adds entrypoint script that syncs npm dependencies when package.json changes
- Prevents stale node_modules in persistent Docker volumes from causing runtime errors on version upgrades

## Problem
When using persistent Docker volumes for `node_modules` (as configured in docker-compose.yml), upgrading CYROID versions can leave stale dependencies that don't match the new `package.json`. This causes runtime errors like:

```
Failed to resolve import "react-resizable-panels" from "src/pages/StudentLab.tsx". Does the file exist?
```

## Solution
Add a `docker-entrypoint.sh` script that:
1. Computes MD5 hash of `package.json`
2. Compares against stored hash in `node_modules/.package-json-hash`
3. Runs `npm install` if hash changed or if deps are incomplete
4. Stores new hash for future comparisons

This ensures dependencies stay in sync across version upgrades without requiring manual `docker volume rm` cleanup.

## Test plan
- [x] Tested upgrade from v0.4.10 to v0.8.4
- [x] Verified new dependencies are auto-installed on container startup
- [x] Verified subsequent startups skip npm install when deps are current

🤖 Generated with [Claude Code](https://claude.ai/code)