### PR TITLE
fix: add iptables to API Dockerfile for network isolation

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libpq-dev \
     p7zip-full \
     genisoimage \
+    iptables \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .


### PR DESCRIPTION
## Summary
- Adds `iptables` package to the API Dockerfile
- The network isolation feature (ddc62a9) added iptables rules but the Dockerfile wasn't updated
- This causes deployment failures with "No such file or directory: 'iptables'" errors

## Test plan
- [x] Verified deployment works after adding iptables to the container
- [ ] Run `docker compose build api` to rebuild the image
- [ ] Deploy a range and verify network isolation works

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)