### PR TITLE
fix: KasmVNC websocket path and sidebar visibility

### DIFF
--- a/backend/cyroid/api/vms.py
+++ b/backend/cyroid/api/vms.py
@@ -1604,13 +1604,11 @@ def get_vm_vnc_info(vm_id: UUID, db: DBSession, current_user: CurrentUser, reque
             if proxy_mapping:
                 # VNC proxy is configured - return connection info
                 # Determine websocket_path based on VM type:
-                # - KasmVNC containers use vnc/{vm.id} (Issue #77)
-                # - QEMU VMs (Windows, Linux) use websockify (standard noVNC path)
-                websocket_path = "websockify"  # Default for QEMU VMs
-                if vm.base_image and vm.base_image.vm_type == "container":
-                    image_tag = (vm.base_image.docker_image_tag or "").lower()
-                    if "kasmweb" in image_tag:
-                        websocket_path = f"vnc/{vm.id}"  # KasmVNC builds WS URL as host + path
+                # - QEMU VMs (linux_vm, windows_vm, macos_vm) use websockify (standard noVNC path)
+                # - All containers use vnc/{vm.id} (KasmVNC builds WS URL as host + path) - Issue #77, #87
+                websocket_path = f"vnc/{vm.id}"  # Default for containers (KasmVNC)
+                if vm.base_image and vm.base_image.vm_type in ("linux_vm", "windows_vm", "macos_vm"):
+                    websocket_path = "websockify"  # QEMU VMs use noVNC websockify path
 
                 return {
                     "vm_id": str(vm.id),

--- a/frontend/src/components/console/VncConsole.tsx
+++ b/frontend/src/components/console/VncConsole.tsx
@@ -56,7 +56,8 @@ export function VncConsole({ vmId, vmHostname, token, onClose }: VncConsoleProps
         // noVNC resolves the path relative to its location, so we just need the websocket endpoint name
         // If noVNC is served from /vnc/{uuid}/ and path=websockify, it connects to /vnc/{uuid}/websockify
         const websocketPath = data.websocket_path ?? 'websockify'
-        const vncUrl = `${origin}${data.path}/?autoconnect=1&resize=scale&path=${websocketPath}`
+        // show_control_bar=true is required for KasmVNC to show sidebar when embedded in iframe
+        const vncUrl = `${origin}${data.path}/?autoconnect=1&resize=scale&path=${websocketPath}&show_control_bar=true`
 
         setVncInfo({
           url: vncUrl,


### PR DESCRIPTION
## Summary
- Use vm_type to determine websocket path - containers use `vnc/{id}`, QEMU VMs use `websockify`
- Add `show_control_bar=true` to VNC URL for KasmVNC sidebar visibility in iframes

## Issues Fixed
- Fixes #77 - KasmVNC websocket path
- Fixes #87 - VNC websocket path for non-kasmweb containers  
- Fixes #89 - KasmVNC sidebar not visible in iframe

## Test plan
- [x] Tested VNC into Kali container - works
- [x] Tested KasmVNC sidebar visibility - works
- [ ] Test VNC into QEMU VM (Windows/Linux) uses websockify path

🤖 Generated with [Claude Code](https://claude.ai/code)