### PR TITLE
fix: pass container_config (privileged, cap_add) to DinD containers

### DIFF
--- a/backend/cyroid/services/docker_service.py
+++ b/backend/cyroid/services/docker_service.py
@@ -2800,6 +2800,7 @@ local-hostname: {name}
         environment: Optional[Dict[str, str]] = None,
         labels: Optional[Dict[str, str]] = None,
         privileged: bool = False,
+        cap_add: Optional[List[str]] = None,
         hostname: Optional[str] = None,
         dns_servers: Optional[str] = None,
         dns_search: Optional[str] = None,
@@ -2850,12 +2851,17 @@ local-hostname: {name}
         if environment is None:
             environment = {}
 
+        # Merge capabilities - always include NET_ADMIN plus any custom caps
+        all_caps = ["NET_ADMIN"]
+        if cap_add:
+            all_caps = list(set(all_caps + cap_add))
+
         host_config_args = {
             "cpu_count": cpu_limit,
             "mem_limit": f"{memory_limit_mb}m",
             "binds": volumes,
             "privileged": privileged,
-            "cap_add": ["NET_ADMIN"],
+            "cap_add": all_caps,
             "restart_policy": {"Name": "unless-stopped"},
             "dns": dns_list
         }


### PR DESCRIPTION
## Summary
DinD container creation now properly reads and applies `container_config` from base images, enabling privileged mode and custom Linux capabilities.

## Changes
- Added `cap_add` parameter to `create_range_container_dind()` in docker_service.py
- Extract `privileged` and `cap_add` from base image's `container_config` in vms.py
- Merge custom capabilities with default `NET_ADMIN`

## Issues Fixed
- Fixes #91 - DinD containers ignore container_config (privileged, cap_add)

## Use Case
Containers like Samba AD DC require privileged mode and SYS_ADMIN capability to function properly. This fix allows base images to specify these requirements in their `container_config`.

## Test plan
- [x] Configured samba-dc base image with `{"privileged": true, "cap_add": ["SYS_ADMIN", "NET_ADMIN"]}`
- [x] Created dc01 VM via UI - starts and stays running
- [ ] Verify container runs with correct capabilities

🤖 Generated with [Claude Code](https://claude.ai/code)