### PR TITLE
fix: improve Student Lab UI panel sizing and VNC connectivity

### DIFF
--- a/backend/cyroid/api/vms.py
+++ b/backend/cyroid/api/vms.py
@@ -1604,13 +1604,11 @@ def get_vm_vnc_info(vm_id: UUID, db: DBSession, current_user: CurrentUser, reque
             if proxy_mapping:
                 # VNC proxy is configured - return connection info
                 # Determine websocket_path based on VM type:
-                # - KasmVNC containers use vnc/{vm.id} (Issue #77)
-                # - QEMU VMs (Windows, Linux) use websockify (standard noVNC path)
+                # - Container VMs use vnc/{vm.id} path (KasmVNC websocket)
+                # - QEMU VMs (linux_vm, windows_vm) use websockify
                 websocket_path = "websockify"  # Default for QEMU VMs
                 if vm.base_image and vm.base_image.vm_type == "container":
-                    image_tag = (vm.base_image.docker_image_tag or "").lower()
-                    if "kasmweb" in image_tag:
-                        websocket_path = f"vnc/{vm.id}"  # KasmVNC builds WS URL as host + path
+                    websocket_path = f"vnc/{vm.id}"  # Container VMs use KasmVNC path
 
                 return {
                     "vm_id": str(vm.id),


### PR DESCRIPTION
## Summary
- Fix Student Lab walkthrough panel collapsing to near-zero width
- Fix VNC console not connecting for custom container images (like cyroid/redteam-kali)

## Changes

### Panel Sizing Fix
Replace buggy `react-resizable-panels` library with custom CSS flexbox implementation:
- Walkthrough panel defaults to **40% width** (was collapsing to ~5%)
- User can drag resize handle to adjust (20-60% range)
- Width persists to localStorage
- Drag overlay prevents iframe from capturing mouse events during resize

### VNC Websocket Path Fix
Simplify VNC websocket path detection for container VMs:
- All container VMs use KasmVNC which requires the `vnc/{vm_id}` websocket path
- Previously checked for "kasmweb" in image tag which missed custom images
- Now uses `vm_type == "container"` check which catches all container VMs

## Test plan
- [ ] Open Student Lab view (`/lab/{rangeId}`)
- [ ] Verify walkthrough panel is visible at ~40% width
- [ ] Drag resize handle to adjust panel width
- [ ] Refresh page and verify width is remembered
- [ ] Click on different VMs and verify VNC console connects
- [ ] Test with custom container images (e.g., cyroid/redteam-kali)

🤖 Generated with [Claude Code](https://claude.com/claude-code)