### PR TITLE
fix: restore clipboard sync between walkthrough and VNC console

### DIFF
--- a/frontend/src/pages/StudentLab.tsx
+++ b/frontend/src/pages/StudentLab.tsx
@@ -6,6 +6,7 @@ import { rangesApi, vmsApi, walkthroughApi } from '../services/api'
 import { Range, VM, Walkthrough } from '../types'
 import { WalkthroughPanel } from '../components/walkthrough'
 import { VMSelector, ConsoleEmbed } from '../components/lab'
+import { VmClipboardProvider } from '../contexts/VmClipboardContext'
 
 export default function StudentLab() {
   const { rangeId } = useParams<{ rangeId: string }>()
@@ -172,6 +173,7 @@ export default function StudentLab() {
   }
 
   return (
+    <VmClipboardProvider>
     <div className="h-screen w-screen bg-gray-900 flex flex-col">
       <div ref={containerRef} className="flex-1 flex overflow-hidden">
         {/* Walkthrough Panel - Guide on the left */}
@@ -243,5 +245,6 @@ export default function StudentLab() {
         <div className="fixed inset-0 z-50 cursor-col-resize" />
       )}
     </div>
+    </VmClipboardProvider>
   )
 }


### PR DESCRIPTION
## Summary
- Restores the clipboard bridge functionality between the student walkthrough and KasmVNC console
- The `VmClipboardProvider` context was missing from the `StudentLab` page wrapper
- Copying code blocks from the walkthrough now properly syncs to the VM clipboard for Ctrl+V paste

## Test plan
- [ ] Open a lab with a walkthrough that has code blocks
- [ ] Copy a code block from the walkthrough (click the copy button)
- [ ] Verify "Clipboard synced!" indicator appears briefly
- [ ] In the VM console, press Ctrl+V to paste the copied text
- [ ] Confirm the text appears correctly in the VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)