### PR TITLE
feat: add content duplicate handling for blueprint and range imports

### DIFF
--- a/backend/cyroid/api/ranges.py
+++ b/backend/cyroid/api/ranges.py
@@ -1925,6 +1925,7 @@ async def execute_import(
     template_conflict_action: str = "use_existing",
     skip_artifacts: bool = False,
     skip_msel: bool = False,
+    skip_walkthrough: bool = False,
     db: DBSession = None,
     current_user: CurrentUser = None,
 ):
@@ -1938,6 +1939,7 @@ async def execute_import(
     - template_conflict_action: "use_existing", "create_new", or "skip"
     - skip_artifacts: Don't import artifacts
     - skip_msel: Don't import MSEL/injects
+    - skip_walkthrough: Don't import Content Library student guide
     """
     from cyroid.services.export_service import get_export_service
 
@@ -1953,6 +1955,7 @@ async def execute_import(
             template_conflict_action=template_conflict_action,
             skip_artifacts=skip_artifacts,
             skip_msel=skip_msel,
+            skip_walkthrough=skip_walkthrough,
         )
 
         export_service = get_export_service()

--- a/frontend/src/components/blueprints/ImportBlueprintModal.tsx
+++ b/frontend/src/components/blueprints/ImportBlueprintModal.tsx
@@ -28,6 +28,7 @@ export default function ImportBlueprintModal({ onClose, onSuccess }: Props) {
   const [validation, setValidation] = useState<BlueprintImportValidation | null>(null);
   const [newName, setNewName] = useState('');
   const [templateStrategy, setTemplateStrategy] = useState<'skip' | 'update' | 'error'>('skip');
+  const [contentStrategy, setContentStrategy] = useState<'skip' | 'rename' | 'use_existing'>('skip');
   const [error, setError] = useState<string | null>(null);
   const [importResult, setImportResult] = useState<{
     blueprintName?: string;
@@ -70,6 +71,7 @@ export default function ImportBlueprintModal({ onClose, onSuccess }: Props) {
     try {
       const options: BlueprintImportOptions = {
         template_conflict_strategy: templateStrategy,
+        content_conflict_strategy: contentStrategy,
       };
 
       // Only set new_name if it's different from the original
@@ -106,6 +108,8 @@ export default function ImportBlueprintModal({ onClose, onSuccess }: Props) {
     setFile(null);
     setValidation(null);
     setNewName('');
+    setTemplateStrategy('skip');
+    setContentStrategy('skip');
     setError(null);
     setImportResult(null);
     setStep('upload');
@@ -251,6 +255,42 @@ export default function ImportBlueprintModal({ onClose, onSuccess }: Props) {
                       <option value="update">Update existing templates</option>
                       <option value="error">Fail if templates exist</option>
                     </select>
+                  </div>
+                )}
+
+                {/* Content Library Info & Conflict */}
+                {validation.content_included && (
+                  <div className="bg-blue-50 rounded-md p-3">
+                    <h4 className="text-sm font-medium text-blue-800 mb-2">
+                      Content Library Item Included
+                    </h4>
+                    {validation.content_conflict ? (
+                      <div className="space-y-3">
+                        <p className="text-sm text-amber-700">
+                          ⚠️ Content with this title already exists: "{validation.content_conflict}"
+                        </p>
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 mb-1">
+                            Content Conflict Strategy
+                          </label>
+                          <select
+                            value={contentStrategy}
+                            onChange={(e) =>
+                              setContentStrategy(e.target.value as 'skip' | 'rename' | 'use_existing')
+                            }
+                            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                          >
+                            <option value="use_existing">Use existing content (don't import)</option>
+                            <option value="rename">Import with new name (add suffix)</option>
+                            <option value="skip">Skip content import entirely</option>
+                          </select>
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="text-sm text-blue-700">
+                        ✓ Content will be imported as a new item
+                      </p>
+                    )}
                   </div>
                 )}
 

--- a/frontend/src/components/import/ImportRangeWizard.tsx
+++ b/frontend/src/components/import/ImportRangeWizard.tsx
@@ -31,6 +31,7 @@ export default function ImportRangeWizard({ isOpen, onClose }: ImportRangeWizard
   >('use_existing')
   const [skipArtifacts, setSkipArtifacts] = useState(false)
   const [skipMsel, setSkipMsel] = useState(false)
+  const [skipWalkthrough, setSkipWalkthrough] = useState(false)
 
   const handleDrag = useCallback((e: React.DragEvent) => {
     e.preventDefault()
@@ -116,6 +117,7 @@ export default function ImportRangeWizard({ isOpen, onClose }: ImportRangeWizard
         template_conflict_action: templateConflictAction,
         skip_artifacts: skipArtifacts,
         skip_msel: skipMsel,
+        skip_walkthrough: skipWalkthrough,
       })
 
       setImportResult(response.data)
@@ -126,7 +128,7 @@ export default function ImportRangeWizard({ isOpen, onClose }: ImportRangeWizard
     } finally {
       setIsLoading(false)
     }
-  }, [file, nameOverride, templateConflictAction, skipArtifacts, skipMsel])
+  }, [file, nameOverride, templateConflictAction, skipArtifacts, skipMsel, skipWalkthrough])
 
   const handleNavigateToRange = useCallback(() => {
     if (importResult?.range_id) {
@@ -145,6 +147,7 @@ export default function ImportRangeWizard({ isOpen, onClose }: ImportRangeWizard
     setTemplateConflictAction('use_existing')
     setSkipArtifacts(false)
     setSkipMsel(false)
+    setSkipWalkthrough(false)
   }, [])
 
   if (!isOpen) return null
@@ -301,6 +304,22 @@ export default function ImportRangeWizard({ isOpen, onClose }: ImportRangeWizard
                       </span>
                     </div>
                   )}
+                  {validationResult.summary.walkthrough_status && (
+                    <div className="col-span-2">
+                      <span className="text-gray-500">Student Walkthrough:</span>
+                      <span className={`ml-2 font-medium ${
+                        validationResult.summary.walkthrough_status === 'create_renamed'
+                          ? 'text-amber-600'
+                          : validationResult.summary.walkthrough_status === 'reuse_existing'
+                          ? 'text-blue-600'
+                          : 'text-green-600'
+                      }`}>
+                        {validationResult.summary.walkthrough_status === 'reuse_existing' && '✓ Will use existing (same content)'}
+                        {validationResult.summary.walkthrough_status === 'create_new' && '+ Will create new'}
+                        {validationResult.summary.walkthrough_status === 'create_renamed' && '⚠ Will create with new name (conflict)'}
+                      </span>
+                    </div>
+                  )}
                 </div>
               </div>
 
@@ -377,6 +396,22 @@ export default function ImportRangeWizard({ isOpen, onClose }: ImportRangeWizard
                   />
                   <span className="ml-2 text-sm text-gray-600">Skip MSEL/injects import</span>
                 </label>
+                {validationResult?.summary.walkthrough_status && (
+                  <label className="flex items-center">
+                    <input
+                      type="checkbox"
+                      checked={skipWalkthrough}
+                      onChange={(e) => setSkipWalkthrough(e.target.checked)}
+                      className="h-4 w-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                    />
+                    <span className="ml-2 text-sm text-gray-600">
+                      Skip student walkthrough import
+                      {validationResult.summary.walkthrough_status === 'create_renamed' && (
+                        <span className="text-amber-600 ml-1">(will create duplicate otherwise)</span>
+                      )}
+                    </span>
+                  </label>
+                )}
               </div>
             </div>
           )}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -347,6 +347,7 @@ export const rangesApi = {
       template_conflict_action?: 'use_existing' | 'create_new' | 'skip'
       skip_artifacts?: boolean
       skip_msel?: boolean
+      skip_walkthrough?: boolean
     } = {}
   ) => {
     const formData = new FormData()
@@ -356,6 +357,7 @@ export const rangesApi = {
     if (options.template_conflict_action) params.append('template_conflict_action', options.template_conflict_action)
     if (options.skip_artifacts) params.append('skip_artifacts', 'true')
     if (options.skip_msel) params.append('skip_msel', 'true')
+    if (options.skip_walkthrough) params.append('skip_walkthrough', 'true')
     const queryString = params.toString()
     const url = queryString ? `/ranges/import/execute?${queryString}` : '/ranges/import/execute'
     return api.post<ImportResult>(url, formData, {
@@ -1098,15 +1100,22 @@ export interface InstanceDeploy {
 export interface BlueprintImportValidation {
   valid: boolean;
   blueprint_name: string;
+  manifest_version?: string;
   errors: string[];
   warnings: string[];
   conflicts: string[];
   missing_templates: string[];
   included_templates: string[];
+  included_dockerfiles: string[];
+  dockerfile_conflicts: string[];
+  missing_images: string[];
+  content_included: boolean;
+  content_conflict: string | null;  // Existing content with same title
 }
 
 export interface BlueprintImportOptions {
   template_conflict_strategy?: 'skip' | 'update' | 'error';
+  content_conflict_strategy?: 'skip' | 'rename' | 'use_existing';
   new_name?: string;
 }
 
@@ -1159,6 +1168,9 @@ export const blueprintsApi = {
     const params = new URLSearchParams();
     if (options.template_conflict_strategy) {
       params.append('template_conflict_strategy', options.template_conflict_strategy);
+    }
+    if (options.content_conflict_strategy) {
+      params.append('content_conflict_strategy', options.content_conflict_strategy);
     }
     if (options.new_name) {
       params.append('new_name', options.new_name);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -726,6 +726,7 @@ export interface ImportSummary {
   artifacts_count: number
   artifact_placements_count: number
   injects_count: number
+  walkthrough_status?: 'reuse_existing' | 'create_new' | 'create_renamed' | null
   estimated_size_mb?: number
 }
 
@@ -742,6 +743,7 @@ export interface ImportOptions {
   template_conflict_action: 'use_existing' | 'create_new' | 'skip'
   skip_artifacts: boolean
   skip_msel: boolean
+  skip_walkthrough: boolean
   dry_run: boolean
 }
 
@@ -753,6 +755,8 @@ export interface ImportResult {
   vms_created: number
   templates_created: number
   artifacts_imported: number
+  walkthrough_imported?: boolean
+  walkthrough_reused?: boolean
   errors: string[]
   warnings: string[]
 }


### PR DESCRIPTION
## Summary
- Blueprint import now shows content conflict detection with strategy options (use existing, rename, skip)
- Range import shows walkthrough status in summary and adds skip checkbox when conflicts detected
- Backend supports skip_walkthrough parameter for range imports

## Test plan
- [ ] Export a blueprint with content, import it twice - verify conflict UI appears
- [ ] Test each content conflict strategy option (use existing, rename, skip)
- [ ] Export a range with walkthrough, import it - verify walkthrough status shows
- [ ] Test skip walkthrough checkbox when conflict detected
- [ ] Verify no duplicate content items created when using "use existing"

🤖 Generated with [Claude Code](https://claude.com/claude-code)