### PR TITLE
fix: Clarify Export vs Blueprint distinction

### DIFF
--- a/frontend/src/components/blueprints/SaveBlueprintModal.tsx
+++ b/frontend/src/components/blueprints/SaveBlueprintModal.tsx
@@ -60,6 +60,11 @@ export default function SaveBlueprintModal({
           </div>
 
           <form onSubmit={handleSubmit} className="p-4 space-y-4">
+            <p className="text-sm text-gray-500 -mt-2 mb-4">
+              Blueprints allow you to quickly deploy multiple instances of this range configuration.
+              For sharing or backup, use "Export Range Package" instead.
+            </p>
+
             <div>
               <label className="block text-sm font-medium text-gray-700">
                 Blueprint Name

--- a/frontend/src/components/export/ExportRangeDialog.tsx
+++ b/frontend/src/components/export/ExportRangeDialog.tsx
@@ -154,9 +154,12 @@ export default function ExportRangeDialog({
         {/* Modal */}
         <div className="relative bg-white rounded-lg shadow-xl max-w-lg w-full p-6">
           <div className="mb-6">
-            <h3 className="text-lg font-semibold text-gray-900">Export Range</h3>
+            <h3 className="text-lg font-semibold text-gray-900">Export Range Package</h3>
             <p className="mt-1 text-sm text-gray-500">
-              Export "{rangeName}" with all configuration for backup or transfer.
+              Create a portable ZIP package of "{rangeName}" for backup, transfer, or offline deployment.
+            </p>
+            <p className="mt-2 text-xs text-gray-400">
+              Tip: Use "Save as Blueprint" instead if you want to create reusable range templates within CYROID.
             </p>
           </div>
 

--- a/frontend/src/pages/RangeDetail.tsx
+++ b/frontend/src/pages/RangeDetail.tsx
@@ -984,7 +984,7 @@ export default function RangeDetail() {
             <button
               onClick={() => setShowExportDialog(true)}
               className="inline-flex items-center px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
-              title="Export Range"
+              title="Export as portable ZIP package for backup or transfer"
             >
               <Download className="h-4 w-4 mr-1" />
               Export
@@ -993,6 +993,7 @@ export default function RangeDetail() {
             <button
               onClick={() => setShowSaveBlueprintModal(true)}
               className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
+              title="Save as reusable blueprint for deploying multiple instances"
             >
               <LayoutTemplate className="h-4 w-4 mr-2" />
               Save as Blueprint


### PR DESCRIPTION
## Summary
Add explanatory text and tooltips to help users understand the difference between Export and Blueprint.

## Changes
- **ExportRangeDialog**: Renamed header to "Export Range Package" and added tip about using Blueprint for internal reuse
- **SaveBlueprintModal**: Added explanation about Blueprint purpose and tip about using Export for sharing
- **RangeDetail**: Updated button tooltips with clearer descriptions

## Use Cases
- **Export Range Package**: Backup, transfer to another CYROID instance, offline deployment
- **Save as Blueprint**: Create reusable templates for deploying multiple instances within the same CYROID

This is a UX improvement toward #131 (full consolidation planned for a future release).

Partial #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)