### PR TITLE
feat: add production deployment system

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,76 @@
+# CYROID Production Environment Configuration
+# Copy this file to .env.prod and customize for your deployment
+#
+# Usage:
+#   cp .env.prod.example .env.prod
+#   # Edit values below
+#   ./scripts/deploy.sh
+#
+# Note: Secrets marked AUTO-GENERATED will be created by deploy.sh if empty
+
+# =============================================================================
+# REQUIRED SETTINGS
+# =============================================================================
+
+# Your domain name OR IP address
+# Examples: cyroid.example.com, 192.168.1.100, 10.0.0.50
+DOMAIN=
+
+# =============================================================================
+# SSL CONFIGURATION
+# =============================================================================
+
+# SSL mode: letsencrypt, selfsigned, or manual
+# - letsencrypt: Automatic certificates via Let's Encrypt (requires domain)
+# - selfsigned: Self-signed certificate (works with IP, shows browser warning)
+# - manual: Use your own certificates in ./certs/
+SSL_MODE=selfsigned
+
+# Email for Let's Encrypt notifications (required for letsencrypt mode)
+ACME_EMAIL=
+
+# =============================================================================
+# AUTO-GENERATED SECRETS (leave empty - deploy.sh will generate)
+# =============================================================================
+
+# JWT secret for authentication (64 random characters)
+JWT_SECRET_KEY=
+
+# PostgreSQL password
+POSTGRES_PASSWORD=
+
+# MinIO (object storage) password
+MINIO_SECRET_KEY=
+
+# =============================================================================
+# OPTIONAL SETTINGS
+# =============================================================================
+
+# Debug mode (default: false in production)
+DEBUG=false
+
+# Data directory (where VM images, ISOs, etc. are stored)
+# Default: /data/cyroid (or current directory for development)
+CYROID_DATA_DIR=/data/cyroid
+
+# Docker-in-Docker image version
+DIND_IMAGE=ghcr.io/jongodb/cyroid-dind:latest
+
+# CYROID version to deploy (latest, or specific version like 0.27.0)
+VERSION=latest
+
+# =============================================================================
+# ADVANCED SETTINGS (usually don't need to change)
+# =============================================================================
+
+# DinD container startup timeout (seconds)
+DIND_STARTUP_TIMEOUT=60
+
+# DinD Docker API port
+DIND_DOCKER_PORT=2375
+
+# Network configuration (don't change unless you have conflicts)
+CYROID_MGMT_NETWORK=cyroid-mgmt
+CYROID_MGMT_SUBNET=172.30.0.0/24
+CYROID_RANGES_NETWORK=cyroid-ranges
+CYROID_RANGES_SUBNET=172.30.1.0/24

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,12 @@ test-results/
 # Certificates
 certs/
 
+# Production environment (contains secrets)
+.env.prod
+
+# ACME/Let's Encrypt data
+acme/
+
 # Traefik dynamic VNC routes (generated at runtime)
 traefik/dynamic/range-*.yml
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,114 @@
+# docker-compose.prod.yml
+#
+# Production overrides for CYROID deployment
+#
+# Usage:
+#   docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# Or use the deploy script:
+#   ./scripts/deploy.sh
+#
+# Key differences from development:
+# - Uses environment variables from .env.prod for secrets
+# - Restart policies for reliability
+# - Production Traefik config with HTTPS redirect
+# - No debug mode
+# - Secure database credentials
+
+services:
+  db:
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    restart: always
+    # Bind to localhost only in production (not externally accessible)
+    ports:
+      - "127.0.0.1:5432:5432"
+
+  redis:
+    restart: always
+    # Bind to localhost only in production
+    ports:
+      - "127.0.0.1:6379:6379"
+
+  minio:
+    environment:
+      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY}
+    restart: always
+    # Only expose console internally, access via Traefik if needed
+    ports:
+      - "127.0.0.1:9001:9001"
+
+  api:
+    image: ghcr.io/jongodb/cyroid-api:${VERSION:-latest}
+    environment:
+      DATABASE_URL: postgresql://cyroid:${POSTGRES_PASSWORD}@172.30.0.11:5432/cyroid
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      DEBUG: "false"
+      # Use production data directory
+      ISO_CACHE_DIR: ${CYROID_DATA_DIR}/iso-cache
+      TEMPLATE_STORAGE_DIR: ${CYROID_DATA_DIR}/template-storage
+      VM_STORAGE_DIR: ${CYROID_DATA_DIR}/vm-storage
+      GLOBAL_SHARED_DIR: ${CYROID_DATA_DIR}/shared
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${CYROID_DATA_DIR}/iso-cache:${CYROID_DATA_DIR}/iso-cache
+      - ${CYROID_DATA_DIR}/template-storage:${CYROID_DATA_DIR}/template-storage
+      - ${CYROID_DATA_DIR}/vm-storage:${CYROID_DATA_DIR}/vm-storage
+      - ${CYROID_DATA_DIR}/shared:${CYROID_DATA_DIR}/shared
+      - ./data/seed-templates:/data/seed-templates:ro
+      - ./data/seed-blueprints:/data/seed-blueprints:ro
+      - ./data/scenarios:/data/scenarios
+      - ./data/images:/data/images
+      - ./traefik/dynamic:/app/traefik/dynamic
+    restart: always
+    labels:
+      # Add TLS configuration for Let's Encrypt (when SSL_MODE=letsencrypt)
+      - "traefik.http.routers.api-secure.tls.certresolver=${SSL_RESOLVER:-}"
+      - "traefik.http.routers.ws-secure.tls.certresolver=${SSL_RESOLVER:-}"
+
+  worker:
+    image: ghcr.io/jongodb/cyroid-worker:${VERSION:-latest}
+    environment:
+      DATABASE_URL: postgresql://cyroid:${POSTGRES_PASSWORD}@172.30.0.11:5432/cyroid
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      DEBUG: "false"
+      ISO_CACHE_DIR: ${CYROID_DATA_DIR}/iso-cache
+      TEMPLATE_STORAGE_DIR: ${CYROID_DATA_DIR}/template-storage
+      VM_STORAGE_DIR: ${CYROID_DATA_DIR}/vm-storage
+      GLOBAL_SHARED_DIR: ${CYROID_DATA_DIR}/shared
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${CYROID_DATA_DIR}/iso-cache:${CYROID_DATA_DIR}/iso-cache
+      - ${CYROID_DATA_DIR}/template-storage:${CYROID_DATA_DIR}/template-storage
+      - ${CYROID_DATA_DIR}/vm-storage:${CYROID_DATA_DIR}/vm-storage
+      - ${CYROID_DATA_DIR}/shared:${CYROID_DATA_DIR}/shared
+      - ./traefik/dynamic:/app/traefik/dynamic
+    restart: always
+
+  frontend:
+    image: ghcr.io/jongodb/cyroid-frontend:${VERSION:-latest}
+    restart: always
+    labels:
+      # Add TLS configuration for Let's Encrypt
+      - "traefik.http.routers.frontend-secure.tls.certresolver=${SSL_RESOLVER:-}"
+
+  traefik:
+    image: ghcr.io/jongodb/cyroid-proxy:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./traefik-prod.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/dynamic:/etc/traefik/dynamic
+      - ./certs:/etc/traefik/certs:ro
+      # ACME certificate storage (persisted for Let's Encrypt)
+      - ./acme:/etc/traefik/acme
+      - traefik-logs:/var/log/traefik
+    restart: always
+    # Only expose HTTP/HTTPS in production (no dashboard)
+    ports:
+      - "80:80"
+      - "443:443"
+
+volumes:
+  traefik-logs:

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,0 +1,352 @@
+# CYROID Production Deployment Guide
+
+This guide covers deploying CYROID for production use on any server - cloud VMs, VPS providers, on-premises servers, or home labs.
+
+## Prerequisites
+
+### System Requirements
+
+- **OS**: Linux (Ubuntu 22.04+ recommended, Debian, RHEL/CentOS 8+)
+- **CPU**: 4+ cores recommended
+- **RAM**: 8GB minimum, 16GB+ recommended
+- **Storage**: 50GB+ for system, additional for VM images
+- **Network**: Static IP or domain name
+
+### Software Requirements
+
+1. **Docker Engine** (v24.0+)
+   ```bash
+   # Ubuntu/Debian
+   curl -fsSL https://get.docker.com | sh
+   sudo usermod -aG docker $USER
+   # Log out and back in
+   ```
+
+2. **Docker Compose** (v2.0+)
+   ```bash
+   # Usually included with Docker Engine
+   docker compose version
+   ```
+
+3. **OpenSSL** (for certificate generation)
+   ```bash
+   # Usually pre-installed
+   openssl version
+   ```
+
+## Quick Start
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/jongodb/cyroid.git
+cd cyroid
+```
+
+### 2. Run the Deployment Script
+
+**Interactive mode (recommended for first-time):**
+```bash
+./scripts/deploy.sh
+```
+
+**With domain and Let's Encrypt:**
+```bash
+./scripts/deploy.sh --domain cyroid.example.com --email admin@example.com
+```
+
+**With IP address (self-signed certificate):**
+```bash
+./scripts/deploy.sh --ip 192.168.1.100
+```
+
+### 3. Access CYROID
+
+Open your browser to `https://your-domain-or-ip`
+
+The first user to register becomes the administrator.
+
+## Deployment Options
+
+### SSL Configuration
+
+| Mode | Use Case | Requirements |
+|------|----------|--------------|
+| `letsencrypt` | Production with domain | Domain pointing to server, ports 80/443 open |
+| `selfsigned` | Internal/IP-only | None (browser will show warning) |
+| `manual` | Bring your own certs | Place certs in `./certs/` |
+
+### Command Line Options
+
+```bash
+./scripts/deploy.sh [OPTIONS]
+
+Options:
+  --domain DOMAIN    Domain name for the server
+  --ip IP            IP address for the server
+  --email EMAIL      Email for Let's Encrypt notifications
+  --ssl MODE         SSL mode: letsencrypt, selfsigned, manual
+  --version VER      CYROID version (default: latest)
+  --data-dir DIR     Data directory (default: /data/cyroid)
+  --update           Update existing deployment
+  --stop             Stop all services
+  --status           Show service status
+```
+
+## Network Configuration
+
+### Required Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 80 | TCP | HTTP (redirects to HTTPS) |
+| 443 | TCP | HTTPS (main access) |
+
+### Firewall Configuration
+
+**UFW (Ubuntu):**
+```bash
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
+```
+
+**firewalld (RHEL/CentOS):**
+```bash
+sudo firewall-cmd --permanent --add-service=http
+sudo firewall-cmd --permanent --add-service=https
+sudo firewall-cmd --reload
+```
+
+### Cloud Provider Security Groups
+
+For AWS, Azure, GCP, etc., ensure your security group/firewall rules allow:
+- Inbound TCP 80 from 0.0.0.0/0
+- Inbound TCP 443 from 0.0.0.0/0
+
+## Data Directories
+
+CYROID stores data in the following locations:
+
+```
+/data/cyroid/                 # Default data directory
+├── iso-cache/                # Downloaded ISO images
+├── template-storage/         # VM templates and golden images
+├── vm-storage/               # Running VM data
+└── shared/                   # Shared files between VMs
+```
+
+To use a different location:
+```bash
+./scripts/deploy.sh --data-dir /path/to/data
+```
+
+## Managing the Deployment
+
+### View Logs
+
+```bash
+# All services
+docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f
+
+# Specific service
+docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f api
+```
+
+### Update to Latest Version
+
+```bash
+./scripts/deploy.sh --update
+```
+
+### Update to Specific Version
+
+```bash
+./scripts/deploy.sh --version 0.27.0 --update
+```
+
+### Stop Services
+
+```bash
+./scripts/deploy.sh --stop
+```
+
+### Check Status
+
+```bash
+./scripts/deploy.sh --status
+```
+
+### Restart Services
+
+```bash
+./scripts/deploy.sh --stop
+./scripts/deploy.sh --update
+```
+
+## Security Hardening
+
+### 1. Secure SSH Access
+
+```bash
+# Disable password authentication
+sudo sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
+sudo systemctl restart sshd
+```
+
+### 2. Automatic Security Updates
+
+```bash
+# Ubuntu
+sudo apt install unattended-upgrades
+sudo dpkg-reconfigure -plow unattended-upgrades
+```
+
+### 3. Secrets
+
+The deployment script automatically generates:
+- JWT secret key (64 characters)
+- PostgreSQL password
+- MinIO password
+
+These are stored in `.env.prod` with restricted permissions.
+
+### 4. Database Security
+
+PostgreSQL is not exposed externally - it's only accessible within the Docker network.
+
+## Backup and Recovery
+
+### Backup Data
+
+```bash
+# Stop services first for consistency
+./scripts/deploy.sh --stop
+
+# Backup data directory
+sudo tar -czf cyroid-backup-$(date +%Y%m%d).tar.gz /data/cyroid
+
+# Backup configuration
+cp .env.prod .env.prod.backup
+cp -r certs certs.backup
+
+# Restart services
+./scripts/deploy.sh --update
+```
+
+### Backup Database
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml exec db \
+  pg_dump -U cyroid cyroid > cyroid-db-backup-$(date +%Y%m%d).sql
+```
+
+### Restore Database
+
+```bash
+# Stop services
+./scripts/deploy.sh --stop
+
+# Start only database
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d db
+
+# Restore
+cat cyroid-db-backup.sql | docker compose -f docker-compose.yml -f docker-compose.prod.yml exec -T db psql -U cyroid cyroid
+
+# Start all services
+./scripts/deploy.sh --update
+```
+
+## Troubleshooting
+
+### Services Not Starting
+
+1. Check Docker status:
+   ```bash
+   sudo systemctl status docker
+   ```
+
+2. Check for port conflicts:
+   ```bash
+   sudo netstat -tlnp | grep -E ':(80|443)'
+   ```
+
+3. View service logs:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml logs
+   ```
+
+### Let's Encrypt Certificate Issues
+
+1. Ensure domain points to server IP
+2. Ensure ports 80/443 are open externally
+3. Check Traefik logs:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml logs traefik
+   ```
+
+### Self-Signed Certificate Regeneration
+
+```bash
+./scripts/generate-certs.sh your-domain-or-ip
+./scripts/deploy.sh --update
+```
+
+### Database Connection Issues
+
+```bash
+# Check database health
+docker compose -f docker-compose.yml -f docker-compose.prod.yml exec db pg_isready -U cyroid
+
+# View database logs
+docker compose -f docker-compose.yml -f docker-compose.prod.yml logs db
+```
+
+### Reset Everything
+
+**Warning: This deletes all data!**
+
+```bash
+./scripts/deploy.sh --stop
+docker volume rm $(docker volume ls -q | grep cyroid)
+rm .env.prod
+./scripts/deploy.sh
+```
+
+## Architecture Overview
+
+```
+                    Internet
+                        |
+                    [Firewall]
+                        |
+                    ┌───────┐
+                    │Traefik│ :80, :443
+                    │(Proxy)│
+                    └───┬───┘
+                        │
+        ┌───────────────┼───────────────┐
+        ▼               ▼               ▼
+   ┌─────────┐    ┌─────────┐    ┌─────────┐
+   │Frontend │    │   API   │    │  VNC    │
+   │ (React) │    │(FastAPI)│    │ Proxy   │
+   └─────────┘    └─────────┘    └─────────┘
+                        │
+                   ┌────┴────┐
+                   ▼         ▼
+              ┌────────┐ ┌───────┐
+              │ Worker │ │ DinD  │
+              │(Tasks) │ │(Ranges)│
+              └────────┘ └───────┘
+                   │
+        ┌──────────┼──────────┐
+        ▼          ▼          ▼
+   ┌─────────┐ ┌───────┐ ┌───────┐
+   │PostgreSQL│ │ Redis │ │ MinIO │
+   └─────────┘ └───────┘ └───────┘
+```
+
+## Support
+
+- **Issues**: https://github.com/jongodb/cyroid/issues
+- **Documentation**: https://github.com/jongodb/cyroid/docs

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,663 @@
+#!/bin/bash
+# CYROID Production Deployment Script
+#
+# Deploys CYROID for production use with automatic SSL and secret generation.
+#
+# Usage:
+#   ./scripts/deploy.sh                                    # Interactive setup
+#   ./scripts/deploy.sh --domain example.com              # Domain with Let's Encrypt
+#   ./scripts/deploy.sh --ip 192.168.1.100                # IP with self-signed cert
+#   ./scripts/deploy.sh --update                          # Update existing deployment
+#   ./scripts/deploy.sh --stop                            # Stop all services
+#   ./scripts/deploy.sh --status                          # Show service status
+#
+# Options:
+#   --domain DOMAIN    Domain name for the server
+#   --ip IP            IP address for the server
+#   --email EMAIL      Email for Let's Encrypt (optional with --domain)
+#   --ssl MODE         SSL mode: letsencrypt, selfsigned, manual (default: auto)
+#   --version VER      CYROID version to deploy (default: latest)
+#   --update           Pull latest images and restart
+#   --stop             Stop all services
+#   --status           Show service status
+#   --help             Show this help message
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+# Get script directory and project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="$PROJECT_ROOT/.env.prod"
+
+# Default values
+DOMAIN=""
+IP=""
+EMAIL=""
+SSL_MODE=""
+VERSION="latest"
+ACTION="deploy"
+DATA_DIR="/data/cyroid"
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+print_banner() {
+    echo -e "${CYAN}"
+    echo "  ██████╗██╗   ██╗██████╗  ██████╗ ██╗██████╗ "
+    echo " ██╔════╝╚██╗ ██╔╝██╔══██╗██╔═══██╗██║██╔══██╗"
+    echo " ██║      ╚████╔╝ ██████╔╝██║   ██║██║██║  ██║"
+    echo " ██║       ╚██╔╝  ██╔══██╗██║   ██║██║██║  ██║"
+    echo " ╚██████╗   ██║   ██║  ██║╚██████╔╝██║██████╔╝"
+    echo "  ╚═════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚═╝╚═════╝ "
+    echo -e "${NC}"
+    echo -e "${BOLD}Cyber Range Orchestrator In Docker${NC}"
+    echo ""
+}
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_step() {
+    echo ""
+    echo -e "${BLUE}==>${NC} ${BOLD}$1${NC}"
+}
+
+generate_secret() {
+    # Generate a random 64-character secret
+    openssl rand -base64 48 | tr -d '/+=' | head -c 64
+}
+
+check_docker() {
+    if ! command -v docker &> /dev/null; then
+        log_error "Docker is not installed. Please install Docker first."
+        log_info "Visit: https://docs.docker.com/get-docker/"
+        exit 1
+    fi
+
+    if ! docker info &> /dev/null; then
+        log_error "Docker daemon is not running or you don't have permission."
+        log_info "Try: sudo systemctl start docker"
+        log_info "Or add your user to the docker group: sudo usermod -aG docker \$USER"
+        exit 1
+    fi
+
+    if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
+        log_error "Docker Compose is not installed."
+        log_info "Visit: https://docs.docker.com/compose/install/"
+        exit 1
+    fi
+}
+
+docker_compose_cmd() {
+    if docker compose version &> /dev/null 2>&1; then
+        docker compose "$@"
+    else
+        docker-compose "$@"
+    fi
+}
+
+show_help() {
+    echo "CYROID Production Deployment Script"
+    echo ""
+    echo "Usage:"
+    echo "  $0                                    Interactive setup"
+    echo "  $0 --domain example.com              Domain with Let's Encrypt"
+    echo "  $0 --ip 192.168.1.100                IP with self-signed cert"
+    echo "  $0 --update                          Update existing deployment"
+    echo "  $0 --stop                            Stop all services"
+    echo "  $0 --status                          Show service status"
+    echo ""
+    echo "Options:"
+    echo "  --domain DOMAIN    Domain name for the server"
+    echo "  --ip IP            IP address for the server"
+    echo "  --email EMAIL      Email for Let's Encrypt notifications"
+    echo "  --ssl MODE         SSL mode: letsencrypt, selfsigned, manual"
+    echo "  --version VER      CYROID version to deploy (default: latest)"
+    echo "  --data-dir DIR     Data directory (default: /data/cyroid)"
+    echo "  --update           Pull latest images and restart"
+    echo "  --stop             Stop all services"
+    echo "  --status           Show service status"
+    echo "  --help             Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  # Deploy with domain and Let's Encrypt"
+    echo "  $0 --domain cyroid.example.com --email admin@example.com"
+    echo ""
+    echo "  # Deploy with IP and self-signed certificate"
+    echo "  $0 --ip 10.0.0.50"
+    echo ""
+    echo "  # Deploy specific version"
+    echo "  $0 --domain cyroid.example.com --version 0.27.0"
+}
+
+# =============================================================================
+# Deployment Functions
+# =============================================================================
+
+create_data_directories() {
+    log_step "Creating data directories"
+
+    sudo mkdir -p "$DATA_DIR"/{iso-cache,template-storage,vm-storage,shared}
+    sudo chown -R "$(id -u):$(id -g)" "$DATA_DIR" 2>/dev/null || true
+
+    log_info "Data directory: $DATA_DIR"
+}
+
+create_env_file() {
+    log_step "Configuring environment"
+
+    # Determine address to use
+    local address="${DOMAIN:-$IP}"
+
+    # Determine SSL mode
+    if [ -z "$SSL_MODE" ]; then
+        if [ -n "$DOMAIN" ]; then
+            SSL_MODE="letsencrypt"
+        else
+            SSL_MODE="selfsigned"
+        fi
+    fi
+
+    # Generate secrets if needed
+    local jwt_secret=""
+    local pg_password=""
+    local minio_password=""
+
+    if [ -f "$ENV_FILE" ]; then
+        # Load existing secrets
+        source "$ENV_FILE" 2>/dev/null || true
+        jwt_secret="${JWT_SECRET_KEY:-}"
+        pg_password="${POSTGRES_PASSWORD:-}"
+        minio_password="${MINIO_SECRET_KEY:-}"
+    fi
+
+    # Generate any missing secrets
+    if [ -z "$jwt_secret" ]; then
+        jwt_secret=$(generate_secret)
+        log_info "Generated JWT secret"
+    fi
+    if [ -z "$pg_password" ]; then
+        pg_password=$(generate_secret | head -c 32)
+        log_info "Generated PostgreSQL password"
+    fi
+    if [ -z "$minio_password" ]; then
+        minio_password=$(generate_secret | head -c 32)
+        log_info "Generated MinIO password"
+    fi
+
+    # Set SSL resolver for Let's Encrypt
+    local ssl_resolver=""
+    if [ "$SSL_MODE" = "letsencrypt" ]; then
+        ssl_resolver="letsencrypt"
+    fi
+
+    # Write environment file
+    cat > "$ENV_FILE" << EOF
+# CYROID Production Environment
+# Generated by deploy.sh on $(date)
+
+# Server Configuration
+DOMAIN=$address
+SSL_MODE=$SSL_MODE
+SSL_RESOLVER=$ssl_resolver
+ACME_EMAIL=${EMAIL:-admin@${address}}
+
+# Secrets (auto-generated)
+JWT_SECRET_KEY=$jwt_secret
+POSTGRES_PASSWORD=$pg_password
+MINIO_SECRET_KEY=$minio_password
+
+# Settings
+DEBUG=false
+VERSION=$VERSION
+CYROID_DATA_DIR=$DATA_DIR
+
+# DinD Configuration
+DIND_IMAGE=ghcr.io/jongodb/cyroid-dind:latest
+DIND_STARTUP_TIMEOUT=60
+DIND_DOCKER_PORT=2375
+
+# Network Configuration
+CYROID_MGMT_NETWORK=cyroid-mgmt
+CYROID_MGMT_SUBNET=172.30.0.0/24
+CYROID_RANGES_NETWORK=cyroid-ranges
+CYROID_RANGES_SUBNET=172.30.1.0/24
+EOF
+
+    chmod 600 "$ENV_FILE"
+    log_info "Environment file: $ENV_FILE"
+    log_info "SSL Mode: $SSL_MODE"
+}
+
+setup_ssl() {
+    log_step "Setting up SSL certificates"
+
+    # Generate production Traefik config with correct email
+    generate_traefik_config
+
+    case "$SSL_MODE" in
+        letsencrypt)
+            log_info "Using Let's Encrypt for automatic certificates"
+            log_info "Certificates will be obtained on first request"
+
+            # Create acme directory and file if it doesn't exist
+            mkdir -p "$PROJECT_ROOT/acme"
+            touch "$PROJECT_ROOT/acme/acme.json"
+            chmod 600 "$PROJECT_ROOT/acme/acme.json"
+            ;;
+
+        selfsigned)
+            log_info "Generating self-signed certificate"
+            "$SCRIPT_DIR/generate-certs.sh" "${DOMAIN:-$IP}"
+            ;;
+
+        manual)
+            if [ ! -f "$PROJECT_ROOT/certs/cert.pem" ] || [ ! -f "$PROJECT_ROOT/certs/key.pem" ]; then
+                log_error "Manual SSL mode requires certificates in ./certs/"
+                log_info "Please place your certificate files:"
+                log_info "  - ./certs/cert.pem"
+                log_info "  - ./certs/key.pem"
+                exit 1
+            fi
+            log_info "Using manually provided certificates"
+            ;;
+    esac
+}
+
+generate_traefik_config() {
+    local acme_email="${EMAIL:-admin@${DOMAIN:-$IP}}"
+    local traefik_config="$PROJECT_ROOT/traefik-prod.yml"
+
+    log_info "Generating Traefik production config"
+
+    cat > "$traefik_config" << EOF
+# Traefik Production Configuration (Generated by deploy.sh)
+#
+# Features:
+# - ACME (Let's Encrypt) automatic certificate management
+# - HTTP to HTTPS redirect
+# - Dashboard disabled for security
+
+api:
+  insecure: false
+  dashboard: false
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+  websecure:
+    address: ":443"
+
+providers:
+  docker:
+    exposedByDefault: false
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: "$acme_email"
+      storage: /etc/traefik/acme/acme.json
+      httpChallenge:
+        entryPoint: web
+
+log:
+  level: WARN
+  format: common
+EOF
+
+    log_info "Traefik config generated with email: $acme_email"
+}
+
+init_networks() {
+    log_step "Initializing Docker networks"
+    "$SCRIPT_DIR/init-networks.sh"
+}
+
+pull_images() {
+    log_step "Pulling Docker images"
+
+    cd "$PROJECT_ROOT"
+
+    # Export env vars for docker-compose
+    export $(grep -v '^#' "$ENV_FILE" | xargs)
+
+    docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml pull
+
+    log_info "Images pulled successfully"
+}
+
+start_services() {
+    log_step "Starting CYROID services"
+
+    cd "$PROJECT_ROOT"
+
+    # Export env vars for docker-compose
+    set -a
+    source "$ENV_FILE"
+    set +a
+
+    docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml up -d
+
+    log_info "Services starting..."
+}
+
+wait_for_health() {
+    log_step "Waiting for services to be healthy"
+
+    local max_attempts=60
+    local attempt=0
+
+    while [ $attempt -lt $max_attempts ]; do
+        if docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml ps 2>/dev/null | grep -q "(healthy)"; then
+            local healthy_count=$(docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml ps 2>/dev/null | grep -c "(healthy)" || echo "0")
+            if [ "$healthy_count" -ge 3 ]; then
+                log_info "All core services are healthy!"
+                return 0
+            fi
+        fi
+
+        attempt=$((attempt + 1))
+        echo -n "."
+        sleep 2
+    done
+
+    echo ""
+    log_warn "Some services may not be fully healthy yet"
+    log_info "Check status with: $0 --status"
+}
+
+show_access_info() {
+    local address="${DOMAIN:-$IP}"
+    local protocol="https"
+
+    echo ""
+    echo -e "${GREEN}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${GREEN}║${NC}            ${BOLD}CYROID Deployment Complete!${NC}                     ${GREEN}║${NC}"
+    echo -e "${GREEN}╠════════════════════════════════════════════════════════════╣${NC}"
+    echo -e "${GREEN}║${NC}                                                            ${GREEN}║${NC}"
+    echo -e "${GREEN}║${NC}  ${CYAN}Access URL:${NC}  ${protocol}://${address}                  ${GREEN}║${NC}"
+    echo -e "${GREEN}║${NC}                                                            ${GREEN}║${NC}"
+    echo -e "${GREEN}║${NC}  ${CYAN}First login:${NC}                                           ${GREEN}║${NC}"
+    echo -e "${GREEN}║${NC}    Register a new account - first user becomes admin      ${GREEN}║${NC}"
+    echo -e "${GREEN}║${NC}                                                            ${GREEN}║${NC}"
+    if [ "$SSL_MODE" = "selfsigned" ]; then
+    echo -e "${GREEN}║${NC}  ${YELLOW}Note:${NC} Using self-signed certificate.                    ${GREEN}║${NC}"
+    echo -e "${GREEN}║${NC}        Browser will show a security warning.               ${GREEN}║${NC}"
+    echo -e "${GREEN}║${NC}        Click 'Advanced' -> 'Proceed' to continue.          ${GREEN}║${NC}"
+    echo -e "${GREEN}║${NC}                                                            ${GREEN}║${NC}"
+    fi
+    echo -e "${GREEN}╚════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+    echo "Useful commands:"
+    echo "  View logs:     docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f"
+    echo "  Stop:          $0 --stop"
+    echo "  Update:        $0 --update"
+    echo "  Status:        $0 --status"
+    echo ""
+}
+
+do_deploy() {
+    print_banner
+
+    # Check prerequisites
+    check_docker
+
+    # If no domain/IP specified, run interactive setup
+    if [ -z "$DOMAIN" ] && [ -z "$IP" ]; then
+        interactive_setup
+    fi
+
+    # Create directories and config
+    create_data_directories
+    create_env_file
+    setup_ssl
+    init_networks
+    pull_images
+    start_services
+    wait_for_health
+    show_access_info
+}
+
+do_update() {
+    print_banner
+    log_step "Updating CYROID deployment"
+
+    check_docker
+
+    if [ ! -f "$ENV_FILE" ]; then
+        log_error "No existing deployment found. Run without --update for initial setup."
+        exit 1
+    fi
+
+    cd "$PROJECT_ROOT"
+
+    # Load environment
+    set -a
+    source "$ENV_FILE"
+    set +a
+
+    # Pull latest images
+    log_info "Pulling latest images..."
+    docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml pull
+
+    # Restart services
+    log_info "Restarting services..."
+    docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml up -d
+
+    wait_for_health
+
+    log_info "Update complete!"
+    echo ""
+}
+
+do_stop() {
+    print_banner
+    log_step "Stopping CYROID services"
+
+    cd "$PROJECT_ROOT"
+
+    if [ -f "$ENV_FILE" ]; then
+        set -a
+        source "$ENV_FILE"
+        set +a
+    fi
+
+    docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml down
+
+    log_info "All services stopped"
+    echo ""
+}
+
+do_status() {
+    print_banner
+    log_step "CYROID Service Status"
+
+    cd "$PROJECT_ROOT"
+
+    if [ -f "$ENV_FILE" ]; then
+        set -a
+        source "$ENV_FILE"
+        set +a
+    fi
+
+    docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml ps
+    echo ""
+}
+
+interactive_setup() {
+    echo -e "${BOLD}Production Deployment Setup${NC}"
+    echo ""
+    echo "This wizard will configure CYROID for production use."
+    echo ""
+
+    # Ask for domain or IP
+    echo -e "${CYAN}How will users access CYROID?${NC}"
+    echo "  1) Domain name (e.g., cyroid.example.com)"
+    echo "  2) IP address (e.g., 192.168.1.100)"
+    echo ""
+    read -p "Enter choice [1-2]: " access_choice
+
+    case "$access_choice" in
+        1)
+            read -p "Enter domain name: " DOMAIN
+            if [ -z "$DOMAIN" ]; then
+                log_error "Domain name cannot be empty"
+                exit 1
+            fi
+
+            echo ""
+            echo -e "${CYAN}SSL Certificate:${NC}"
+            echo "  1) Let's Encrypt (automatic, free, requires domain to be publicly accessible)"
+            echo "  2) Self-signed (works immediately, shows browser warning)"
+            echo ""
+            read -p "Enter choice [1-2]: " ssl_choice
+
+            case "$ssl_choice" in
+                1)
+                    SSL_MODE="letsencrypt"
+                    read -p "Enter email for Let's Encrypt notifications: " EMAIL
+                    ;;
+                2)
+                    SSL_MODE="selfsigned"
+                    ;;
+                *)
+                    SSL_MODE="selfsigned"
+                    ;;
+            esac
+            ;;
+        2)
+            read -p "Enter IP address: " IP
+            if [ -z "$IP" ]; then
+                log_error "IP address cannot be empty"
+                exit 1
+            fi
+            SSL_MODE="selfsigned"
+            ;;
+        *)
+            log_error "Invalid choice"
+            exit 1
+            ;;
+    esac
+
+    # Data directory
+    echo ""
+    read -p "Data directory [$DATA_DIR]: " input_data_dir
+    if [ -n "$input_data_dir" ]; then
+        DATA_DIR="$input_data_dir"
+    fi
+
+    echo ""
+    echo -e "${GREEN}Configuration Summary:${NC}"
+    echo "  Address:    ${DOMAIN:-$IP}"
+    echo "  SSL Mode:   $SSL_MODE"
+    echo "  Data Dir:   $DATA_DIR"
+    echo ""
+    read -p "Proceed with deployment? [Y/n]: " confirm
+
+    if [[ "$confirm" =~ ^[Nn] ]]; then
+        log_info "Deployment cancelled"
+        exit 0
+    fi
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --domain)
+            DOMAIN="$2"
+            shift 2
+            ;;
+        --ip)
+            IP="$2"
+            shift 2
+            ;;
+        --email)
+            EMAIL="$2"
+            shift 2
+            ;;
+        --ssl)
+            SSL_MODE="$2"
+            shift 2
+            ;;
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --data-dir)
+            DATA_DIR="$2"
+            shift 2
+            ;;
+        --update)
+            ACTION="update"
+            shift
+            ;;
+        --stop)
+            ACTION="stop"
+            shift
+            ;;
+        --status)
+            ACTION="status"
+            shift
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Change to project root
+cd "$PROJECT_ROOT"
+
+# Execute action
+case "$ACTION" in
+    deploy)
+        do_deploy
+        ;;
+    update)
+        do_update
+        ;;
+    stop)
+        do_stop
+        ;;
+    status)
+        do_status
+        ;;
+esac

--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# CYROID Self-Signed Certificate Generator
+#
+# Generates a self-signed certificate for HTTPS access when not using
+# Let's Encrypt (e.g., for IP-only deployments or internal use).
+#
+# Usage:
+#   ./scripts/generate-certs.sh                    # Interactive
+#   ./scripts/generate-certs.sh example.com        # Domain
+#   ./scripts/generate-certs.sh 192.168.1.100      # IP address
+#
+# Output:
+#   ./certs/cert.pem  - Certificate
+#   ./certs/key.pem   - Private key
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get script directory and project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+CERTS_DIR="$PROJECT_ROOT/certs"
+
+echo -e "${GREEN}=== CYROID Certificate Generator ===${NC}"
+echo ""
+
+# Get hostname/IP from argument or prompt
+if [ $# -ge 1 ]; then
+    HOSTNAME="$1"
+else
+    echo -e "${YELLOW}Enter the hostname or IP address for the certificate:${NC}"
+    read -p "> " HOSTNAME
+fi
+
+# Validate input
+if [ -z "$HOSTNAME" ]; then
+    echo -e "${RED}Error: Hostname/IP cannot be empty${NC}"
+    exit 1
+fi
+
+# Create certs directory
+mkdir -p "$CERTS_DIR"
+
+# Check if certificates already exist
+if [ -f "$CERTS_DIR/cert.pem" ] && [ -f "$CERTS_DIR/key.pem" ]; then
+    echo -e "${YELLOW}Existing certificates found in $CERTS_DIR${NC}"
+    read -p "Overwrite? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Keeping existing certificates."
+        exit 0
+    fi
+fi
+
+echo ""
+echo "Generating self-signed certificate for: $HOSTNAME"
+echo ""
+
+# Determine if input is an IP address or domain
+if [[ "$HOSTNAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    # IP address
+    SAN="IP:$HOSTNAME"
+    CN="$HOSTNAME"
+else
+    # Domain name
+    SAN="DNS:$HOSTNAME,DNS:*.$HOSTNAME"
+    CN="$HOSTNAME"
+fi
+
+# Generate certificate with proper SAN extension
+openssl req -x509 -nodes -days 365 \
+    -newkey rsa:2048 \
+    -keyout "$CERTS_DIR/key.pem" \
+    -out "$CERTS_DIR/cert.pem" \
+    -subj "/CN=$CN/O=CYROID/OU=Cyber Range" \
+    -addext "subjectAltName=$SAN" \
+    -addext "keyUsage=digitalSignature,keyEncipherment" \
+    -addext "extendedKeyUsage=serverAuth" \
+    2>/dev/null
+
+# Set permissions
+chmod 644 "$CERTS_DIR/cert.pem"
+chmod 600 "$CERTS_DIR/key.pem"
+
+echo -e "${GREEN}Certificate generated successfully!${NC}"
+echo ""
+echo "Files created:"
+echo "  - $CERTS_DIR/cert.pem (certificate)"
+echo "  - $CERTS_DIR/key.pem (private key)"
+echo ""
+echo "Certificate details:"
+openssl x509 -in "$CERTS_DIR/cert.pem" -noout -subject -dates 2>/dev/null | sed 's/^/  /'
+echo ""
+echo -e "${YELLOW}Note: This is a self-signed certificate. Browsers will show a security warning.${NC}"
+echo "Users can bypass the warning or install the certificate to trust it."

--- a/traefik-prod.yml
+++ b/traefik-prod.yml
@@ -1,0 +1,60 @@
+# Traefik Production Configuration
+#
+# This configuration adds:
+# - ACME (Let's Encrypt) automatic certificate management
+# - HTTP to HTTPS redirect
+# - Secure dashboard (disabled by default)
+#
+# See: https://doc.traefik.io/traefik/reference/static-configuration/file/
+
+api:
+  # Dashboard disabled in production (enable with basic auth if needed)
+  insecure: false
+  dashboard: false
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+  websecure:
+    address: ":443"
+
+providers:
+  # Docker provider for container labels
+  docker:
+    exposedByDefault: false
+
+  # File provider watching directory for dynamic config
+  # Contains: base.yml (TLS, serversTransport) + vnc-*.yml (VNC routes)
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+
+# ACME (Let's Encrypt) Certificate Configuration
+# Note: This is a template. The deploy.sh script generates the actual
+# traefik-prod.yml with the correct email address.
+# This resolver is used when SSL_MODE=letsencrypt
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      # Email for certificate notifications (set by deploy.sh)
+      email: "admin@localhost"
+      # Certificate storage file
+      storage: /etc/traefik/acme/acme.json
+      # HTTP-01 challenge (port 80)
+      httpChallenge:
+        entryPoint: web
+
+# Logging
+log:
+  level: WARN
+  format: common
+
+accessLog:
+  filePath: "/var/log/traefik/access.log"
+  bufferingSize: 100

--- a/traefik/dynamic/production.yml
+++ b/traefik/dynamic/production.yml
@@ -1,0 +1,54 @@
+# Traefik Production Dynamic Configuration
+#
+# This file is only used in production mode and provides:
+# - HTTP to HTTPS redirect middleware
+# - Secure TLS configuration
+#
+# Note: This is loaded by Traefik's file provider watching /etc/traefik/dynamic/
+
+http:
+  # Middlewares
+  middlewares:
+    # HTTPS redirect (handled by entrypoint in traefik-prod.yml, this is backup)
+    https-redirect:
+      redirectScheme:
+        scheme: https
+        permanent: true
+
+    # Security headers
+    security-headers:
+      headers:
+        frameDeny: true
+        browserXssFilter: true
+        contentTypeNosniff: true
+        referrerPolicy: "strict-origin-when-cross-origin"
+
+  serversTransports:
+    # Transport for containers with self-signed certs (KasmVNC, etc.)
+    insecure-transport:
+      insecureSkipVerify: true
+
+tls:
+  # Default certificate store
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /etc/traefik/certs/cert.pem
+        keyFile: /etc/traefik/certs/key.pem
+
+  # Certificate configuration (fallback for self-signed)
+  certificates:
+    - certFile: /etc/traefik/certs/cert.pem
+      keyFile: /etc/traefik/certs/key.pem
+      stores:
+        - default
+
+  # TLS options
+  options:
+    default:
+      minVersion: VersionTLS12
+      sniStrict: false
+      cipherSuites:
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305


### PR DESCRIPTION
## Summary

Adds a flexible production deployment system for CYROID that allows deployment on any server (cloud VMs, VPS, on-prem, home lab) with automatic SSL configuration and secret generation.

### New Files
- `scripts/deploy.sh` - Main deployment script with interactive setup wizard
- `scripts/generate-certs.sh` - Self-signed certificate generator for IP-only deployments
- `docker-compose.prod.yml` - Production Docker Compose overrides
- `traefik-prod.yml` - Production Traefik config with ACME/Let's Encrypt support
- `.env.prod.example` - Production environment template
- `docs/production-deployment.md` - Comprehensive deployment documentation
- `traefik/dynamic/production.yml` - Production TLS and security headers

### Features
- **Single command deployment**: `./scripts/deploy.sh` handles everything
- **Flexible SSL options**:
  - Let's Encrypt (automatic, free) for domain-based deployments
  - Self-signed certificates for IP-only or internal deployments
  - Manual certificate support for bring-your-own certs
- **Auto-generated secrets**: JWT secret, PostgreSQL password, MinIO password
- **Security hardened**:
  - HTTP to HTTPS redirect enforced
  - Database and Redis bound to localhost only
  - Dashboard disabled in production
- **Interactive setup wizard** for first-time deployment

### Usage

```bash
# Interactive (recommended for first-time)
./scripts/deploy.sh

# Domain with Let's Encrypt
./scripts/deploy.sh --domain cyroid.example.com --email admin@example.com

# IP with self-signed certificate  
./scripts/deploy.sh --ip 192.168.1.100

# Update existing deployment
./scripts/deploy.sh --update

# Check status
./scripts/deploy.sh --status
```

## Test plan

- [ ] Test interactive deployment wizard
- [ ] Test self-signed certificate generation
- [ ] Test Let's Encrypt configuration (requires public domain)
- [ ] Verify HTTP to HTTPS redirect
- [ ] Verify all services start and are healthy
- [ ] Test student remote access to VNC consoles
- [ ] Test update and stop commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)