### PR TITLE
feat: allow reactivating cancelled training events

### DIFF
--- a/frontend/src/pages/TrainingEventDetail.tsx
+++ b/frontend/src/pages/TrainingEventDetail.tsx
@@ -22,6 +22,7 @@ import {
   Rocket,
   Loader2,
   ExternalLink,
+  RotateCcw,
 } from 'lucide-react'
 import {
   trainingEventsApi,
@@ -272,7 +273,7 @@ export default function TrainingEventDetail() {
     }
   }
 
-  async function handleStatusChange(action: 'publish' | 'start' | 'complete' | 'cancel', autoDeploy = false) {
+  async function handleStatusChange(action: 'publish' | 'start' | 'complete' | 'cancel' | 'reactivate', autoDeploy = false) {
     if (!id) return
     try {
       switch (action) {
@@ -287,6 +288,9 @@ export default function TrainingEventDetail() {
           break
         case 'cancel':
           await trainingEventsApi.cancel(id)
+          break
+        case 'reactivate':
+          await trainingEventsApi.reactivate(id)
           break
       }
       await loadEvent(id)
@@ -402,6 +406,15 @@ export default function TrainingEventDetail() {
               >
                 <XCircle className="h-4 w-4 mr-1" />
                 Cancel
+              </button>
+            )}
+            {event.status === 'cancelled' && (
+              <button
+                onClick={() => handleStatusChange('reactivate')}
+                className="inline-flex items-center px-3 py-1.5 border border-amber-300 text-sm font-medium rounded text-amber-700 bg-amber-50 hover:bg-amber-100"
+              >
+                <RotateCcw className="h-4 w-4 mr-1" />
+                Reactivate
               </button>
             )}
           </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1889,6 +1889,9 @@ export const trainingEventsApi = {
   cancel: (id: string) =>
     api.post<TrainingEvent>(`/training-events/${id}/cancel`),
 
+  reactivate: (id: string) =>
+    api.post<TrainingEvent>(`/training-events/${id}/reactivate`),
+
   // Participants
   listParticipants: (eventId: string) =>
     api.get<EventParticipant[]>(`/training-events/${eventId}/participants`),


### PR DESCRIPTION
## Summary

- Adds the ability to reactivate cancelled training events
- Cancelled events return to DRAFT status when reactivated
- From there, the user can publish (schedule) or start the event immediately

## Changes

- Add `POST /{event_id}/reactivate` endpoint to backend
- Add `reactivate` API method to frontend
- Add "Reactivate" button (amber colored) in TrainingEventDetail for cancelled events

## Test plan

- [ ] Cancel a training event
- [ ] Verify "Reactivate" button appears for cancelled events
- [ ] Click Reactivate and verify event returns to DRAFT status
- [ ] Verify you can then publish or start the event

🤖 Generated with [Claude Code](https://claude.com/claude-code)