### PR TITLE
refactor: make content statically referenced, not duplicated per range

### DIFF
--- a/backend/cyroid/api/ranges.py
+++ b/backend/cyroid/api/ranges.py
@@ -389,11 +389,8 @@ def delete_range(range_id: UUID, db: DBSession, current_user: CurrentUser):
         logger.warning(f"Failed to cleanup Docker resources for range {range_id}: {e}")
         # Continue with database deletion even if Docker cleanup fails
 
-    # Delete auto-generated content associated with this range (Issue #152)
-    # This cleans up content created during blueprint deployment
-    deleted_content = db.query(Content).filter(Content.source_range_id == range_id).delete()
-    if deleted_content > 0:
-        logger.info(f"Deleted {deleted_content} auto-generated content item(s) for range {range_id}")
+    # Content is no longer deleted with ranges - it's statically defined and shared
+    # across range instances. Content is only deleted when its parent blueprint is deleted.
 
     # Delete associated range instances (from blueprint deployments) to avoid FK constraint (Issue #73)
     db.query(RangeInstance).filter(RangeInstance.range_id == range_id).delete()

--- a/backend/cyroid/api/training_events.py
+++ b/backend/cyroid/api/training_events.py
@@ -581,13 +581,14 @@ def start_event(
 def _delete_event_ranges(event_id: UUID, db: Session) -> int:
     """Delete all ranges associated with event participants.
 
-    Also cleans up auto-generated content linked to those ranges (Issue #152).
+    Content is no longer deleted with ranges - it's statically defined and shared
+    across range instances. Content is only deleted when its parent blueprint is deleted.
+
     Returns the number of ranges deleted.
     """
     import asyncio
     from cyroid.models.range import Range
     from cyroid.models.blueprint import RangeInstance
-    from cyroid.models.content import Content
     from cyroid.services.docker_service import get_docker_service
     from cyroid.services.dind_service import get_dind_service
 
@@ -625,11 +626,6 @@ def _delete_event_ranges(event_id: UUID, db: Session) -> int:
 
             except Exception as e:
                 logger.warning(f"Failed to cleanup Docker for range {range_id}: {e}")
-
-            # Delete auto-generated content for this range (Issue #152)
-            deleted_content = db.query(Content).filter(Content.source_range_id == range_id).delete()
-            if deleted_content > 0:
-                logger.info(f"Deleted {deleted_content} auto-generated content item(s) for range {range_id}")
 
             # Delete range instances (FK constraint)
             db.query(RangeInstance).filter(RangeInstance.range_id == range_id).delete()

--- a/backend/cyroid/services/blueprint_export_service.py
+++ b/backend/cyroid/services/blueprint_export_service.py
@@ -1323,14 +1323,25 @@ class BlueprintExportService:
             # ============================================================
             # Create the Blueprint
             # ============================================================
+            # Build content_ids list - include imported content for static reference
+            blueprint_content_ids: List[str] = []
+            if content_id:
+                blueprint_content_ids.append(str(content_id))
+
+            # Also update config's content_ids so deploy uses the static reference
+            config_dict = export_data.blueprint.config.model_dump()
+            if content_id:
+                config_dict["content_ids"] = blueprint_content_ids
+
             blueprint = RangeBlueprint(
                 name=blueprint_name,
                 description=export_data.blueprint.description,
-                config=export_data.blueprint.config.model_dump(),
+                config=config_dict,
                 base_subnet_prefix=export_data.blueprint.base_subnet_prefix,
                 version=export_data.blueprint.version,
                 next_offset=0,  # Reset offset for new instance
                 created_by=user.id,
+                content_ids=blueprint_content_ids,  # Link imported content
             )
             db.add(blueprint)
             db.commit()


### PR DESCRIPTION
## Summary
- Content (student guides/walkthroughs) is now statically defined and shared across range instances
- Content is created once during blueprint import and linked to the blueprint's `content_ids`
- Ranges reference existing content via `student_guide_id` instead of each creating their own copy
- Content is only deleted when its parent blueprint is deleted

## Changes
| File | Change |
|------|--------|
| `blueprint_service.py` | Reference existing content from `config.content_ids` instead of creating new |
| `ranges.py` | Remove content deletion on range delete |
| `training_events.py` | Remove content deletion on event cleanup |
| `blueprint_export_service.py` | Link imported content to `blueprint.content_ids` |
| `blueprints.py` | Delete associated content when blueprint is deleted |

## Test plan
- [ ] Import a blueprint with walkthrough content
- [ ] Verify content is created and linked to blueprint.content_ids
- [ ] Deploy a range from the blueprint
- [ ] Verify range.student_guide_id references the existing content
- [ ] Delete the range
- [ ] Verify content still exists
- [ ] Delete the blueprint
- [ ] Verify content is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)