### PR TITLE
fix(ci): validate multi-arch manifests contain both platforms

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -132,6 +132,8 @@ jobs:
           GIT_REF: ${{ github.ref }}
           GIT_REF_NAME: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
+
           # Determine tags based on event type
           if [[ "$GIT_REF" == refs/tags/v* ]]; then
             # Tag push - create version tags
@@ -170,13 +172,29 @@ jobs:
           GIT_REF: ${{ github.ref }}
           GIT_REF_NAME: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
+
+          verify_manifest() {
+            local tag="$1"
+            echo "Verifying ${IMAGE}:${tag} is a multi-arch manifest..."
+            local inspect_output
+            inspect_output=$(docker buildx imagetools inspect "${IMAGE}:${tag}" 2>&1)
+            echo "$inspect_output"
+
+            # Check that both architectures are present
+            for arch in amd64 arm64; do
+              if ! echo "$inspect_output" | grep -q "linux/${arch}"; then
+                echo "::error::${IMAGE}:${tag} is missing linux/${arch} platform"
+                return 1
+              fi
+            done
+            echo "✓ ${IMAGE}:${tag} contains both amd64 and arm64"
+          }
+
           if [[ "$GIT_REF" == refs/heads/master ]]; then
-            echo "Inspecting ${IMAGE}:latest"
-            docker buildx imagetools inspect "${IMAGE}:latest"
+            verify_manifest "latest"
           elif [[ "$GIT_REF" == refs/tags/v* ]]; then
-            VERSION_TAG="${GIT_REF_NAME#v}"
-            echo "Inspecting ${IMAGE}:${VERSION_TAG}"
-            docker buildx imagetools inspect "${IMAGE}:${VERSION_TAG}"
+            verify_manifest "${GIT_REF_NAME#v}"
           fi
 
   # Build infrastructure image wrappers (thin layers over upstream images)
@@ -327,6 +345,8 @@ jobs:
           GIT_REF: ${{ github.ref }}
           GIT_REF_NAME: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
+
           if [[ "$GIT_REF" == refs/tags/v* ]]; then
             VERSION_TAG="${GIT_REF_NAME#v}"
             MAJOR_MINOR=$(echo "$VERSION_TAG" | cut -d. -f1,2)
@@ -351,4 +371,35 @@ jobs:
             docker buildx imagetools create -t "${IMAGE}:${VERSION}" \
               "${IMAGE}:${VERSION}-amd64" \
               "${IMAGE}:${VERSION}-arm64"
+          fi
+
+      - name: Verify multi-arch manifest
+        env:
+          IMAGE: ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          GIT_REF: ${{ github.ref }}
+          GIT_REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          verify_manifest() {
+            local tag="$1"
+            echo "Verifying ${IMAGE}:${tag} is a multi-arch manifest..."
+            local inspect_output
+            inspect_output=$(docker buildx imagetools inspect "${IMAGE}:${tag}" 2>&1)
+            echo "$inspect_output"
+
+            for arch in amd64 arm64; do
+              if ! echo "$inspect_output" | grep -q "linux/${arch}"; then
+                echo "::error::${IMAGE}:${tag} is missing linux/${arch} platform"
+                return 1
+              fi
+            done
+            echo "✓ ${IMAGE}:${tag} contains both amd64 and arm64"
+          }
+
+          if [[ "$GIT_REF" == refs/heads/master ]]; then
+            verify_manifest "latest"
+          elif [[ "$GIT_REF" == refs/tags/v* ]]; then
+            verify_manifest "${GIT_REF_NAME#v}"
           fi


### PR DESCRIPTION
## Summary

The `:latest` tags for `cyroid-frontend` and `cyroid-worker` are currently single-platform `arm64` manifests instead of multi-arch manifest lists. On amd64 hosts this causes QEMU emulation, which crashes nginx at startup with `io_setup() failed (38: Function not implemented)` and adds unnecessary overhead to the worker.

The per-architecture tags (`master-amd64`, `master-arm64`) exist for both images — the builds succeed but the manifest creation silently failed, and the verification step did not catch it.

### Changes

**CI workflow** (`docker-publish.yml`):
- Add `set -euo pipefail` to manifest creation scripts so errors in `imagetools create` are not silently ignored
- Replace the inspect-only verification with a `verify_manifest` function that fails the CI job if either `linux/amd64` or `linux/arm64` is missing from the published manifest
- Add the same verification step to infrastructure manifests, which previously had none

**Deploy script** (`scripts/deploy.sh`):
- Capture the exit code from `docker compose pull` instead of letting it abort the deployment — log a warning and continue with locally available images
- After pulling, inspect each image and warn if its architecture doesn't match the host, making QEMU emulation issues visible before they cause cryptic runtime errors

## Test plan

- [ ] CI run on this PR branch passes (build jobs only, no manifest push on PRs)
- [ ] After merge to master, verify `create-manifests` and `create-infrastructure-manifests` jobs include the new verification step
- [ ] Confirm `docker manifest inspect ghcr.io/jongodb/cyroid-frontend:latest` returns a `manifest.list.v2+json` with both `amd64` and `arm64` entries
- [ ] Confirm `docker manifest inspect ghcr.io/jongodb/cyroid-worker:latest` returns a `manifest.list.v2+json` with both `amd64` and `arm64` entries
- [ ] Run `deploy.sh` on an amd64 host with intentionally mismatched images — verify the platform mismatch warning is displayed and deployment continues
- [ ] Deploy on an amd64 host and verify `frontend` (nginx) starts without `io_setup()` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)