### PR TITLE
fix(deploy): Address 5 deployment issues from Linux amd64 testing

### DIFF
--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -43,9 +43,9 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # Expose port 80
 EXPOSE 80
 
-# Health check
+# Health check (use 127.0.0.1 to avoid IPv6 resolution issues)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1/health || exit 1
 
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     server {
         listen 80;
+        listen [::]:80;
         server_name _;
         root /usr/share/nginx/html;
         index index.html;


### PR DESCRIPTION
## Summary

Fixes 5 deployment issues discovered during Linux amd64 testing.

## Issues Fixed

### Issue 1: Registry Config Created as Directory Instead of File
- **Problem:** `config/registry-config.yml` was created as a directory, causing registry container to fail
- **Fix:** Add proper file creation in `create_data_directories()`, remove directory if incorrectly created

### Issue 2: Frontend Healthcheck Fails (IPv6 vs IPv4)
- **Problem:** `wget` resolves `localhost` to IPv6 `[::1]` first, but nginx only listened on IPv4
- **Fix:** Change healthcheck from `localhost` to `127.0.0.1`

### Issue 3: Traefik Not Routing to Frontend
- **Problem:** Traefik couldn't discover frontend service on docker network
- **Fix:** Add `network: cyroid-mgmt` to traefik docker provider config

### Issue 4: Containers Created But Not Started
- **Problem:** Race condition left some containers in "Created" state
- **Fix:** Add retry logic in `start_services()` to start any stuck containers

### Issue 5: Nginx IPv6 Support
- **Problem:** Nginx only listened on IPv4
- **Fix:** Add `listen [::]:80` for full IPv6 compatibility

## Files Changed
- `scripts/deploy.sh` - Registry config creation, traefik network config, container retry logic
- `frontend/Dockerfile.prod` - Healthcheck uses 127.0.0.1
- `frontend/nginx.conf` - Added IPv6 listen directive

## Test Plan
- [ ] Deploy on Linux amd64 with `./deploy.sh`
- [ ] Verify registry config is created as a file
- [ ] All containers show "Up" status
- [ ] Frontend shows "healthy" status
- [ ] `curl -sk https://localhost/` returns frontend HTML
- [ ] Traefik logs show `frontend@docker` router

Addresses #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)