### PR TITLE
fix(deploy): address round 2 deployment issues

### DIFF
--- a/backend/cyroid/main.py
+++ b/backend/cyroid/main.py
@@ -92,10 +92,16 @@ Include it in the `Authorization` header: `Bearer <token>`
 
 ## API Documentation
 
-- **OpenAPI JSON**: `/openapi.json`
-- **Swagger UI**: `/docs`
-- **ReDoc**: `/redoc`
+- **Swagger UI**: `/docs` (interactive API explorer)
+- **ReDoc**: `/redoc` (alternative documentation view)
+- **OpenAPI JSON**: `/openapi.json` (machine-readable schema)
 - **AI Context**: `/api/v1/schema/ai-context` (condensed guide for AI assistants)
+
+## Health Checks
+
+- `/health` - Basic health check
+- `/api/health` - API health check (alias)
+- `/api/v1/health` - Versioned health check (alias)
 """
 
 app = FastAPI(
@@ -103,6 +109,9 @@ app = FastAPI(
     description=API_DESCRIPTION,
     version=settings.app_version,
     lifespan=lifespan,
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
     openapi_tags=[
         {"name": "auth", "description": "Authentication and user management"},
         {"name": "users", "description": "User account management"},
@@ -160,7 +169,10 @@ app.include_router(registry_router, prefix="/api/v1")
 
 
 @app.get("/health")
+@app.get("/api/health")
+@app.get("/api/v1/health")
 async def health_check():
+    """Health check endpoint for load balancers and monitoring."""
     return {"status": "healthy", "app": settings.app_name}
 
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -203,6 +203,7 @@ bootstrap_standalone() {
         "docker-compose.prod.yml"
         "traefik/dynamic/base.yml"
         "traefik/dynamic/production.yml"
+        "config/registry-config.yml"
     )
 
     for file in "${files_to_download[@]}"; do


### PR DESCRIPTION
## Summary
- **Issue 6**: Add `/api/health` and `/api/v1/health` endpoints for standardized health checks
- **Issue 8**: Add explicit `docs_url`, `redoc_url`, `openapi_url` to FastAPI app configuration
- **Issue 9**: Add `config/registry-config.yml` to bootstrap download list

## Changes
- `backend/cyroid/main.py`: Added additional health endpoint routes, explicit OpenAPI docs configuration
- `scripts/deploy.sh`: Added registry config to files downloaded during bootstrap

## Test Plan
- [ ] Verify `/api/health` returns healthy status
- [ ] Verify `/api/v1/health` returns healthy status
- [ ] Verify `/docs` shows Swagger UI
- [ ] Verify `/redoc` shows ReDoc
- [ ] Verify bootstrap downloads registry config on fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)