### PR TITLE
fix(deploy): round 3 deployment improvements

### DIFF
--- a/backend/cyroid/config.py
+++ b/backend/cyroid/config.py
@@ -95,6 +95,9 @@ class Settings(BaseSettings):
     app_name: str = "CYROID"
     debug: bool = True
 
+    # CORS (comma-separated list of allowed origins, or "*" for all)
+    cors_origins: str = "http://localhost:5173,http://localhost:3000"
+
     # Image/ISO Cache (platform-aware defaults)
     iso_cache_dir: str = os.path.join(_get_default_data_dir(), "iso-cache")
     template_storage_dir: str = os.path.join(_get_default_data_dir(), "template-storage")

--- a/backend/cyroid/main.py
+++ b/backend/cyroid/main.py
@@ -132,9 +132,16 @@ app = FastAPI(
     ],
 )
 
+# Parse CORS origins from config (comma-separated string or "*" for all)
+cors_origins = settings.cors_origins
+if cors_origins == "*":
+    cors_allow_origins = ["*"]
+else:
+    cors_allow_origins = [origin.strip() for origin in cors_origins.split(",") if origin.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:3000"],
+    allow_origins=cors_allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,6 +40,7 @@ services:
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
       DEBUG: "false"
+      CORS_ORIGINS: "*"
       # Use production data directory
       ISO_CACHE_DIR: ${CYROID_DATA_DIR}/iso-cache
       TEMPLATE_STORAGE_DIR: ${CYROID_DATA_DIR}/template-storage
@@ -57,6 +58,12 @@ services:
       - ${CYROID_DATA_DIR}/images:/data/images
       - ./traefik/dynamic:/app/traefik/dynamic
     restart: always
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     labels:
       # Add TLS configuration for Let's Encrypt (when SSL_MODE=letsencrypt)
       - "traefik.http.routers.api-secure.tls.certresolver=${SSL_RESOLVER:-}"
@@ -85,6 +92,12 @@ services:
       - ${CYROID_DATA_DIR}/images:/data/images
       - ./traefik/dynamic:/app/traefik/dynamic
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f dramatiq || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   frontend:
     image: ghcr.io/jongodb/cyroid-frontend:${VERSION:-latest}


### PR DESCRIPTION
## Summary
Addresses deployment issues from testing report (round 3):

### Critical Fixes
- **Non-interactive mode**: Add `-y`/`--yes` flag for CI/CD pipelines
- **Admin CLI flags**: Add `--admin-user`, `--admin-password`, `--admin-email` for automated deployments
- **cyroid-dind auto-pull**: Image now pulled automatically during deployment

### Medium Priority
- **API healthcheck**: Added wget-based healthcheck for API service
- **Worker healthcheck**: Added process-based healthcheck for Dramatiq worker
- **Configurable CORS**: `CORS_ORIGINS` env var (comma-separated or `*` for all)

## Usage

Fully automated deployment:
```bash
./deploy.sh -y --ip 192.168.1.100 --ssl selfsigned --admin-user admin --admin-password mypassword
```

## Test Plan
- [ ] Deploy with `-y` flag (non-interactive)
- [ ] Verify admin user created with CLI credentials
- [ ] Verify cyroid-dind image pulled automatically
- [ ] Verify API and worker show healthy status
- [ ] Verify CORS works with any origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)