### PR TITLE
fix(deploy): round 5 fixes - traefik healthcheck and platform pulls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,6 +244,11 @@ services:
 
   traefik:
     image: ghcr.io/jongodb/cyroid-proxy:latest
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8082/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     # Use static config file instead of command line args
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1238,8 +1238,8 @@ backup_images() {
             progress_bar_update "$current" "$image_count" "Backup" "Pulling: $img"
             echo "  [$current/$image_count] $img"
 
-            # First pull from registry to ensure we have it locally
-            if ! docker pull "$img" >/dev/null 2>&1; then
+            # First pull from registry to ensure we have it locally (with explicit platform)
+            if ! docker pull --platform "$DOCKER_PLATFORM" "$img" >/dev/null 2>&1; then
                 echo -e "    ${RED}✗${NC} Failed to pull from registry"
                 failed=$((failed + 1))
                 continue
@@ -2506,8 +2506,8 @@ pull_images() {
 
             echo "  [$current/$total] $name"
 
-            # Pull individual image (DOCKER_DEFAULT_PLATFORM is exported by detect_platform)
-            if docker pull "$img" >/dev/null 2>&1; then
+            # Pull individual image with explicit platform to avoid multi-arch issues
+            if docker pull --platform "$DOCKER_PLATFORM" "$img" >/dev/null 2>&1; then
                 echo -e "    ${GREEN}✓${NC} Pulled"
             else
                 echo -e "    ${YELLOW}⚠${NC} May already exist locally"

--- a/traefik-prod.yml
+++ b/traefik-prod.yml
@@ -12,7 +12,14 @@ api:
   insecure: false
   dashboard: false
 
+# Health check ping endpoint
+ping:
+  entryPoint: traefik
+
 entryPoints:
+  # Internal entrypoint for health checks
+  traefik:
+    address: ":8082"
   web:
     address: ":80"
     http:

--- a/traefik.yml
+++ b/traefik.yml
@@ -5,7 +5,14 @@ api:
   insecure: true
   dashboard: true
 
+# Health check ping endpoint
+ping:
+  entryPoint: traefik
+
 entryPoints:
+  # Internal entrypoint for health checks
+  traefik:
+    address: ":8082"
   web:
     address: ":80"
   websecure:


### PR DESCRIPTION
## Summary

### Issue 1: Traefik healthcheck missing
- Added healthcheck to traefik service in `docker-compose.yml`
- Added `ping` entryPoint (port 8082) to `traefik.yml` and `traefik-prod.yml`
- Enabled `/ping` endpoint for health checks

### Issue 2: Multi-arch image pull errors
- Added explicit `--platform` flag to all `docker pull` commands
- Fixes "image does not provide the specified platform" errors
- Ensures correct architecture images are pulled on amd64/arm64

## Files Changed
- `docker-compose.yml` - traefik healthcheck
- `traefik.yml` - ping entrypoint (dev)
- `traefik-prod.yml` - ping entrypoint (prod)
- `scripts/deploy.sh` - platform flag for pulls

## Test Plan
- [ ] Traefik reports healthy status
- [ ] All 8 services healthy
- [ ] Image pulls work correctly on both amd64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)