### PR TITLE
fix: health check count bug and database wait loops

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: bash -c "alembic upgrade head && uvicorn cyroid.main:app --host 0.0.0.0 --port 8000"
+    command: bash -c "until python -c \"import psycopg2; psycopg2.connect('$${DATABASE_URL}')\" 2>/dev/null; do echo 'Waiting for database...'; sleep 2; done && alembic upgrade head && uvicorn cyroid.main:app --host 0.0.0.0 --port 8000"
     labels:
       - "traefik.enable=true"
       # API service
@@ -193,7 +193,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: dramatiq cyroid.tasks --processes 2 --threads 4
+    command: bash -c "until python -c \"import psycopg2; psycopg2.connect('$${DATABASE_URL}')\" 2>/dev/null; do echo 'Waiting for database...'; sleep 2; done && dramatiq cyroid.tasks --processes 2 --threads 4"
 
   registry:
     image: registry:2

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2613,8 +2613,10 @@ wait_for_health() {
     local target_healthy=8  # All 8 services should be healthy
 
     while [ $attempt -lt $max_attempts ]; do
-        local healthy_count=$(docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml ps 2>/dev/null | grep -c "(healthy)" || echo "0")
-        local running_count=$(docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml ps 2>/dev/null | grep -c "Up" || echo "0")
+        local healthy_count
+        healthy_count=$(docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml ps 2>/dev/null | grep -c "(healthy)") || healthy_count=0
+        local running_count
+        running_count=$(docker_compose_cmd -f docker-compose.yml -f docker-compose.prod.yml ps 2>/dev/null | grep -c "Up") || running_count=0
 
         # Update progress bar
         if [ "$TUI_FULLSCREEN" = true ]; then


### PR DESCRIPTION
## Summary
- Fix `grep -c` pattern in deploy.sh that caused `"0\n0"` output breaking integer comparison
- Add database wait loops to api and worker services for Intel Mac compatibility

## Details

### Issue 1: Health check count bug
The pattern `$(... | grep -c "pattern" || echo "0")` causes `"0\n0"` when grep finds no matches because `grep -c` exits with code 1 on zero matches, triggering the `|| echo "0"`.

**Before:** `[: 0\n0: integer expression expected` error
**After:** Proper integer variable assignment with fallback

### Issue 2: Database connection failures on Intel Macs
Docker Desktop networking delays on Intel Macs caused psycopg2 connection failures, resulting in only 6/8 services becoming healthy.

**Fix:** Add `until python -c "import psycopg2; psycopg2.connect(...)"` wait loop before alembic/dramatiq commands.

## Test plan
- [ ] Deploy on Intel Mac - verify 8/8 services healthy
- [ ] Deploy on Apple Silicon - verify no regression
- [ ] Verify no "[: integer expression expected" errors

🤖 Generated with [Claude Code](https://claude.ai/code)